### PR TITLE
refactor: remove rule is_default flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,13 @@ Endpoints:
 #### Configuration Management (requires admin login)
 * `POST /config/dry_run` - Toggle dry run mode (body: `{"dry_run": true|false, "updated_by": "optional-string"}`)
 * `POST /config/panic_stop` - Emergency stop all processing (body: `{"panic_stop": true|false, "updated_by": "optional-string"}`)
-* `POST /config/rules/reload` - Reload rules.yml configuration
+
+#### Rule Management (requires admin login)
+* `GET /rules` - List all rules
+* `POST /rules` - Create a rule
+* `PUT /rules/{id}` - Update a rule
+* `DELETE /rules/{id}` - Delete a rule
+* `POST /rules/{id}/toggle` - Enable or disable a rule
 
 #### Analytics & Data (requires admin login)
 * `GET /analytics/overview` - System analytics overview with account/report metrics

--- a/app/api/rules.py
+++ b/app/api/rules.py
@@ -32,7 +32,7 @@ def get_current_rules(user: User = Depends(require_admin_hybrid)):
 
 @router.get("/rules", tags=["rules"])
 def list_rules(user: User = Depends(require_admin_hybrid)):
-    """List all rules (file-based and database rules)."""
+    """List all rules."""
     all_rules, _, _ = rule_service.get_active_rules()
     response = []
 

--- a/app/models.py
+++ b/app/models.py
@@ -64,9 +64,20 @@ class Rule(Base):
     pattern = Column(Text, nullable=False)
     weight = Column(Numeric, nullable=False)
     enabled = Column(Boolean, nullable=False, default=True)
-    is_default = Column(Boolean, nullable=False, default=False)  # True for rules from rules.yml
     # New columns for action types and duration
-    action_type = Column(sa_Enum('report', 'silence', 'suspend', 'disable', 'sensitive', 'domain_block', name='action_type_enum', create_type=False), nullable=False)
+    action_type = Column(
+        sa_Enum(
+            "report",
+            "silence",
+            "suspend",
+            "disable",
+            "sensitive",
+            "domain_block",
+            name="action_type_enum",
+            create_type=False,
+        ),
+        nullable=False,
+    )
     action_duration_seconds = Column(Integer, nullable=True)
     action_warning_text = Column(Text, nullable=True)
     warning_preset_id = Column(Text, nullable=True)
@@ -84,6 +95,7 @@ class Rule(Base):
 
 class DomainAlert(Base):
     """Track domain-level violations and defederation thresholds"""
+
     __tablename__ = "domain_alerts"
     id = Column(BigInteger, primary_key=True)
     domain = Column(Text, nullable=False, unique=True)
@@ -100,10 +112,11 @@ class DomainAlert(Base):
 
 class ScanSession(Base):
     """Track scanning sessions and progress across multiple users/accounts"""
+
     __tablename__ = "scan_sessions"
     id = Column(BigInteger, primary_key=True)
     session_type = Column(Text, nullable=False)  # 'local', 'remote', 'federated'
-    status = Column(Text, nullable=False, default='active')  # 'active', 'completed', 'paused', 'failed'
+    status = Column(Text, nullable=False, default="active")  # 'active', 'completed', 'paused', 'failed'
     accounts_processed = Column(Integer, nullable=False, default=0)
     total_accounts = Column(Integer)  # Estimated total if known
     current_cursor = Column(Text)  # Current position in the scan
@@ -116,6 +129,7 @@ class ScanSession(Base):
 
 class ContentScan(Base):
     """Track individual content scans to prevent re-processing"""
+
     __tablename__ = "content_scans"
     id = Column(BigInteger, primary_key=True)
     content_hash = Column(Text, nullable=False, unique=True)  # Hash of content being scanned
@@ -132,7 +146,19 @@ class ScheduledAction(Base):
     __tablename__ = "scheduled_actions"
     id = Column(BigInteger, primary_key=True)
     mastodon_account_id = Column(Text, index=True, nullable=False)
-    action_to_reverse = Column(sa_Enum('report', 'silence', 'suspend', 'disable', 'sensitive', 'domain_block', name='action_type_enum', create_type=False), nullable=False)
+    action_to_reverse = Column(
+        sa_Enum(
+            "report",
+            "silence",
+            "suspend",
+            "disable",
+            "sensitive",
+            "domain_block",
+            name="action_type_enum",
+            create_type=False,
+        ),
+        nullable=False,
+    )
     expires_at = Column(TIMESTAMP(timezone=True), index=True, nullable=False)
 
 
@@ -159,7 +185,7 @@ class AuditLog(Base):
     __tablename__ = "audit_log"
     id = Column(BigInteger, primary_key=True)
     action_type = Column(Text, nullable=False)
-    triggered_by_rule_id = Column(BigInteger, ForeignKey('rules.id'), nullable=True)
+    triggered_by_rule_id = Column(BigInteger, ForeignKey("rules.id"), nullable=True)
     target_account_id = Column(Text, nullable=False)
     timestamp = Column(TIMESTAMP(timezone=True), server_default=func.now())
     evidence = Column(JSON)

--- a/db/migrations/versions/007_drop_is_default_column.py
+++ b/db/migrations/versions/007_drop_is_default_column.py
@@ -1,0 +1,27 @@
+"""Drop is_default column from rules table
+
+Revision ID: 007_drop_is_default_column
+Revises: 006_scanning_system
+Create Date: 2025-02-14 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "007_drop_is_default_column"
+down_revision = "006_scanning_system"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_index("ix_rules_is_default", table_name="rules")
+    op.drop_column("rules", "is_default")
+
+
+def downgrade():
+    op.add_column(
+        "rules",
+        sa.Column("is_default", sa.Boolean(), nullable=False, server_default="false"),
+    )
+    op.create_index("ix_rules_is_default", "rules", ["is_default"])

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -806,7 +806,7 @@ function RulesTab({ rules, onReload, saving }: {
   }
 
   async function handleToggleRule(rule: Rule) {
-    if (rule.is_default || !rule.id) return;
+    if (!rule.id) return;
     
     try {
       setLoading(true);
@@ -821,7 +821,7 @@ function RulesTab({ rules, onReload, saving }: {
   }
 
   async function handleDeleteRule(rule: Rule) {
-    if (rule.is_default || !rule.id) return;
+    if (!rule.id) return;
     
     try {
       setLoading(true);
@@ -914,9 +914,6 @@ function RulesTab({ rules, onReload, saving }: {
                             <Text size="sm" fw={500} c={rule.enabled ? undefined : 'dimmed'}>
                               {rule.name}
                             </Text>
-                            {rule.is_default && (
-                              <Badge size="xs" color="blue" variant="light">Default</Badge>
-                            )}
                             <Badge size="xs" variant="light" color={rule.enabled ? 'green' : 'gray'}>
                               {rule.enabled ? 'On' : 'Off'}
                             </Badge>
@@ -937,7 +934,7 @@ function RulesTab({ rules, onReload, saving }: {
                           <Text size="xs" c="dimmed">Weight: {rule.weight}</Text>
                         </Stack>
                         <Group gap={4}>
-                          {!rule.is_default && rule.id && (
+                          {rule.id && (
                             <>
                               <ActionIcon
                                 size="sm"
@@ -1095,9 +1092,6 @@ function RulesTab({ rules, onReload, saving }: {
               </div>
               <Group>
                 <Badge variant="light">{selectedRuleForInfo.rule_type}</Badge>
-                {selectedRuleForInfo.is_default && (
-                  <Badge color="blue">Default Rule</Badge>
-                )}
               </Group>
             </Group>
             
@@ -1755,10 +1749,7 @@ function ScanningTab({
                   <Stat label="Enabled Rules" value={ruleStatistics.enabled_rules.toString()} />
                 </Grid.Col>
                 <Grid.Col span={6}>
-                  <Stat label="Custom Rules" value={ruleStatistics.custom_rules.toString()} />
-                </Grid.Col>
-                <Grid.Col span={6}>
-                  <Stat label="File Rules" value={ruleStatistics.file_rules.toString()} />
+                  <Stat label="Disabled Rules" value={ruleStatistics.disabled_rules.toString()} />
                 </Grid.Col>
               </Grid>
             </Grid.Col>

--- a/frontend/src/analytics.ts
+++ b/frontend/src/analytics.ts
@@ -77,9 +77,9 @@ export type AnalysisData = {
 export type RulesData = {
   rules: {
     report_threshold: number;
-    username_regex?: Array<{name: string; pattern: string; weight: number; enabled?: boolean; is_default?: boolean; id?: number}>;
-    display_name_regex?: Array<{name: string; pattern: string; weight: number; enabled?: boolean; is_default?: boolean; id?: number}>;
-    content_regex?: Array<{name: string; pattern: string; weight: number; enabled?: boolean; is_default?: boolean; id?: number}>;
+    username_regex?: Array<{name: string; pattern: string; weight: number; enabled?: boolean; id?: number}>;
+    display_name_regex?: Array<{name: string; pattern: string; weight: number; enabled?: boolean; id?: number}>;
+    content_regex?: Array<{name: string; pattern: string; weight: number; enabled?: boolean; id?: number}>;
   };
   report_threshold: number;
 };
@@ -91,7 +91,6 @@ export type Rule = {
   pattern: string;
   weight: number;
   enabled: boolean;
-  is_default: boolean;
   trigger_count?: number;
   last_triggered_at?: string | null;
   last_triggered_content?: any;
@@ -152,8 +151,7 @@ export type DomainAnalytics = {
 export type RuleStatistics = {
   total_rules: number;
   enabled_rules: number;
-  custom_rules: number;
-  file_rules: number;
+  disabled_rules: number;
   top_triggered_rules: Array<{
     name: string;
     trigger_count: number;
@@ -205,7 +203,7 @@ export async function fetchRulesList(): Promise<RulesList> {
   return apiFetch<RulesList>('/rules');
 }
 
-export async function createRule(rule: Omit<Rule, 'id' | 'is_default'>): Promise<Rule> {
+export async function createRule(rule: Omit<Rule, 'id'>): Promise<Rule> {
   return apiFetch<Rule>('/rules', {
     method: 'POST',
     body: JSON.stringify(rule)


### PR DESCRIPTION
## Summary
- drop is_default from rules table
- strip default rule logic from UI and analytics types
- document database-backed rule management

## Testing
- `npm --prefix frontend run build`
- `make test` *(fails: module 'app' has no attribute 'main')*
- `DATABASE_URL=sqlite:///test.db alembic upgrade head` *(fails: Settings validation error)*

------
https://chatgpt.com/codex/tasks/task_e_68912327125883228a5221aec4349ff1