### PR TITLE
refactor: remove rules reload feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ Endpoints:
 #### Configuration Management (requires admin login)
 * `POST /config/dry_run` - Toggle dry run mode (body: `{"dry_run": true|false, "updated_by": "optional-string"}`)
 * `POST /config/panic_stop` - Emergency stop all processing (body: `{"panic_stop": true|false, "updated_by": "optional-string"}`)
-* `POST /config/rules/reload` - Reload rules.yml configuration
 
 #### Analytics & Data (requires admin login)
 * `GET /analytics/overview` - System analytics overview with account/report metrics

--- a/app/models.py
+++ b/app/models.py
@@ -64,9 +64,21 @@ class Rule(Base):
     pattern = Column(Text, nullable=False)
     weight = Column(Numeric, nullable=False)
     enabled = Column(Boolean, nullable=False, default=True)
-    is_default = Column(Boolean, nullable=False, default=False)  # True for rules from rules.yml
+    is_default = Column(Boolean, nullable=False, default=False)
     # New columns for action types and duration
-    action_type = Column(sa_Enum('report', 'silence', 'suspend', 'disable', 'sensitive', 'domain_block', name='action_type_enum', create_type=False), nullable=False)
+    action_type = Column(
+        sa_Enum(
+            "report",
+            "silence",
+            "suspend",
+            "disable",
+            "sensitive",
+            "domain_block",
+            name="action_type_enum",
+            create_type=False,
+        ),
+        nullable=False,
+    )
     action_duration_seconds = Column(Integer, nullable=True)
     action_warning_text = Column(Text, nullable=True)
     warning_preset_id = Column(Text, nullable=True)
@@ -84,6 +96,7 @@ class Rule(Base):
 
 class DomainAlert(Base):
     """Track domain-level violations and defederation thresholds"""
+
     __tablename__ = "domain_alerts"
     id = Column(BigInteger, primary_key=True)
     domain = Column(Text, nullable=False, unique=True)
@@ -100,10 +113,11 @@ class DomainAlert(Base):
 
 class ScanSession(Base):
     """Track scanning sessions and progress across multiple users/accounts"""
+
     __tablename__ = "scan_sessions"
     id = Column(BigInteger, primary_key=True)
     session_type = Column(Text, nullable=False)  # 'local', 'remote', 'federated'
-    status = Column(Text, nullable=False, default='active')  # 'active', 'completed', 'paused', 'failed'
+    status = Column(Text, nullable=False, default="active")  # 'active', 'completed', 'paused', 'failed'
     accounts_processed = Column(Integer, nullable=False, default=0)
     total_accounts = Column(Integer)  # Estimated total if known
     current_cursor = Column(Text)  # Current position in the scan
@@ -116,6 +130,7 @@ class ScanSession(Base):
 
 class ContentScan(Base):
     """Track individual content scans to prevent re-processing"""
+
     __tablename__ = "content_scans"
     id = Column(BigInteger, primary_key=True)
     content_hash = Column(Text, nullable=False, unique=True)  # Hash of content being scanned
@@ -132,7 +147,19 @@ class ScheduledAction(Base):
     __tablename__ = "scheduled_actions"
     id = Column(BigInteger, primary_key=True)
     mastodon_account_id = Column(Text, index=True, nullable=False)
-    action_to_reverse = Column(sa_Enum('report', 'silence', 'suspend', 'disable', 'sensitive', 'domain_block', name='action_type_enum', create_type=False), nullable=False)
+    action_to_reverse = Column(
+        sa_Enum(
+            "report",
+            "silence",
+            "suspend",
+            "disable",
+            "sensitive",
+            "domain_block",
+            name="action_type_enum",
+            create_type=False,
+        ),
+        nullable=False,
+    )
     expires_at = Column(TIMESTAMP(timezone=True), index=True, nullable=False)
 
 
@@ -159,7 +186,7 @@ class AuditLog(Base):
     __tablename__ = "audit_log"
     id = Column(BigInteger, primary_key=True)
     action_type = Column(Text, nullable=False)
-    triggered_by_rule_id = Column(BigInteger, ForeignKey('rules.id'), nullable=True)
+    triggered_by_rule_id = Column(BigInteger, ForeignKey("rules.id"), nullable=True)
     target_account_id = Column(Text, nullable=False)
     timestamp = Column(TIMESTAMP(timezone=True), server_default=func.now())
     evidence = Column(JSON)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -296,15 +296,6 @@ export default function App() {
     }
   }
 
-  async function reloadRules() {
-    setSaving(true);
-    try {
-      await apiFetch('/config/rules/reload', { method: 'POST' });
-      await loadRules();
-    } finally {
-      setSaving(false);
-    }
-  }
 
   // Show login screen if not authenticated
   if (authLoading) {
@@ -446,7 +437,7 @@ export default function App() {
             </Tabs.Panel>
 
             <Tabs.Panel value="rules" pt="md">
-              <RulesTab rules={rules} onReload={reloadRules} saving={saving} />
+              <RulesTab rules={rules} saving={saving} />
             </Tabs.Panel>
 
             <Tabs.Panel value="scanning" pt="md">
@@ -469,11 +460,10 @@ export default function App() {
             </Tabs.Panel>
 
             <Tabs.Panel value="settings" pt="md">
-              <SettingsTab 
+              <SettingsTab
                 health={health}
                 onUpdateDryRun={updateDryRun}
                 onUpdatePanic={updatePanic}
-                onReloadRules={reloadRules}
                 saving={saving}
               />
             </Tabs.Panel>
@@ -753,10 +743,9 @@ function ReportsTab({ reports }: { reports: ReportData | null }) {
   );
 }
 
-function RulesTab({ rules, onReload, saving }: { 
-  rules: RulesData | null, 
-  onReload: () => void,
-  saving: boolean 
+function RulesTab({ rules, saving }: {
+  rules: RulesData | null,
+  saving: boolean
 }) {
   const [rulesList, setRulesList] = useState<Rule[]>([]);
   const [loading, setLoading] = useState(false);
@@ -797,7 +786,6 @@ function RulesTab({ rules, onReload, saving }: {
       setNewRule({ name: '', rule_type: 'username_regex', pattern: '', weight: 0.5 });
       setShowCreateModal(false);
       await loadRulesList();
-      onReload();
     } catch (error) {
       console.error('Failed to create rule:', error);
     } finally {
@@ -812,7 +800,6 @@ function RulesTab({ rules, onReload, saving }: {
       setLoading(true);
       await toggleRule(rule.id);
       await loadRulesList();
-      onReload();
     } catch (error) {
       console.error('Failed to toggle rule:', error);
     } finally {
@@ -827,7 +814,6 @@ function RulesTab({ rules, onReload, saving }: {
       setLoading(true);
       await deleteRule(rule.id);
       await loadRulesList();
-      onReload();
     } catch (error) {
       console.error('Failed to delete rule:', error);
     } finally {
@@ -847,7 +833,6 @@ function RulesTab({ rules, onReload, saving }: {
       });
       setEditingRule(null);
       await loadRulesList();
-      onReload();
     } catch (error) {
       console.error('Failed to update rule:', error);
     } finally {
@@ -876,20 +861,12 @@ function RulesTab({ rules, onReload, saving }: {
             </Text>
           </Stack>
           <Group>
-            <Button 
-              variant="light" 
+            <Button
+              variant="light"
               leftSection={<IconPlus size={16} />}
               onClick={() => setShowCreateModal(true)}
             >
               Add Rule
-            </Button>
-            <Button 
-              variant="light" 
-              leftSection={<IconRefresh size={16} />}
-              onClick={onReload}
-              loading={saving}
-            >
-              Reload Rules
             </Button>
           </Group>
         </Group>
@@ -1195,11 +1172,10 @@ function RulesTab({ rules, onReload, saving }: {
   );
 }
 
-function SettingsTab({ health, onUpdateDryRun, onUpdatePanic, onReloadRules, saving }: {
+function SettingsTab({ health, onUpdateDryRun, onUpdatePanic, saving }: {
   health: Health | null,
   onUpdateDryRun: (next: boolean) => void,
   onUpdatePanic: (next: boolean) => void,
-  onReloadRules: () => void,
   saving: boolean
 }) {
   const [configError, setConfigError] = useState<string | null>(null);
@@ -1346,41 +1322,6 @@ function SettingsTab({ health, onUpdateDryRun, onUpdatePanic, onReloadRules, sav
             />
           </Group>
           
-          <Divider />
-          
-          <Group justify="space-between" align="flex-start">
-            <div>
-              <Group gap="xs" align="center">
-                <Text fw={500}>Rules Configuration</Text>
-                <Tooltip 
-                  label="Reloads rules.yml into memory without restarting."
-                  withArrow
-                  position="top"
-                  multiline
-                  w={300}
-                  aria-label="Rules Configuration information"
-                >
-                  <IconInfoCircle size={16} style={{ color: 'var(--mantine-color-dimmed)', cursor: 'help' }} />
-                </Tooltip>
-              </Group>
-              <Text size="sm" c="dimmed">
-                Reload moderation rules from the configuration file. 
-                This will apply any changes made to rules.yml without restarting the service.
-              </Text>
-            </div>
-            <Button 
-              variant="light" 
-              leftSection={<IconRefresh size={16} />}
-              onClick={() => handleConfigUpdate(
-                async () => onReloadRules(),
-                'Rules configuration reloaded successfully'
-              )} 
-              disabled={saving}
-              loading={saving}
-            >
-              Reload Rules
-            </Button>
-          </Group>
         </Stack>
       </Card>
 


### PR DESCRIPTION
## Summary
- remove deprecated rules reload UI and API docs
- drop leftover rules.yml references

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.clients.mastodon.client')*
- `make lint` *(fails: many style errors)*

------
https://chatgpt.com/codex/tasks/task_e_6891230d43ac8322850a13d6187d5829