### PR TITLE
refactor: drop legacy rule eval helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Endpoints:
 * `GET /api/v1/me` - Get current user information
 
 #### Testing & Validation  
-* `POST /dryrun/evaluate` - Test rule evaluation (body: `{"account": {...}, "statuses": [...]})`)
+* `POST /dryrun/evaluate` - Test rule evaluation (body: `{"account": {...}, "statuses": [...]}`) → `{ "score": float, "hits": [[rule_name, score, evidence], ...]}`
 
 #### Webhooks
 * `POST /webhooks/status` - Webhook endpoint for Mastodon status updates (requires signature validation)

--- a/app/main.py
+++ b/app/main.py
@@ -140,7 +140,9 @@ def metrics():
 async def dryrun_evaluate(payload: dict):
     acct = payload.get("account") or {}
     statuses = payload.get("statuses") or []
-    score, hits = rule_service.eval_account(acct, statuses)
+    violations = rule_service.evaluate_account(acct, statuses)
+    score = sum(v.score for v in violations)
+    hits = [(v.rule_name, v.score, v.evidence.dict()) for v in violations]
     return {"score": score, "hits": hits}
 
 

--- a/app/scanning.py
+++ b/app/scanning.py
@@ -20,6 +20,7 @@ settings = get_settings()
 @dataclass
 class ScanProgress:
     """Track progress of scanning operations"""
+
     session_id: int
     session_type: str
     accounts_processed: int
@@ -31,41 +32,40 @@ class ScanProgress:
 
 class EnhancedScanningSystem:
     """Enhanced scanning system with improved efficiency and federated tracking"""
-    
+
     def __init__(self):
         # Use the centralized rule service instead of loading from files
         self.rule_service = rule_service
         self.settings = get_settings()
-    
+
     def start_scan_session(self, session_type: str, metadata: Optional[Dict] = None) -> int:
         """Start a new scanning session"""
         with SessionLocal() as session:
             # Check if there's already an active session of this type
-            existing = session.query(ScanSession).filter(
-                and_(
-                    ScanSession.session_type == session_type,
-                    ScanSession.status == 'active'
-                )
-            ).first()
-            
+            existing = (
+                session.query(ScanSession)
+                .filter(and_(ScanSession.session_type == session_type, ScanSession.status == "active"))
+                .first()
+            )
+
             if existing:
                 logger.info(f"Active {session_type} scan session already exists: {existing.id}")
                 return existing.id
-            
+
             scan_session = ScanSession(
                 session_type=session_type,
-                status='active',
+                status="active",
                 rules_applied=self._get_current_rules_snapshot(),
-                session_metadata=metadata or {}
+                session_metadata=metadata or {},
             )
             session.add(scan_session)
             session.commit()
             session.refresh(scan_session)
-            
+
             logger.info(f"Started new {session_type} scan session: {scan_session.id}")
             return scan_session.id
-    
-    def complete_scan_session(self, session_id: int, status: str = 'completed'):
+
+    def complete_scan_session(self, session_id: int, status: str = "completed"):
         """Mark a scan session as completed"""
         with SessionLocal() as session:
             scan_session = session.query(ScanSession).filter(ScanSession.id == session_id).first()
@@ -74,241 +74,218 @@ class EnhancedScanningSystem:
                 scan_session.completed_at = datetime.utcnow()
                 session.commit()
                 logger.info(f"Scan session {session_id} marked as {status}")
-    
+
     def get_scan_progress(self, session_id: int) -> Optional[ScanProgress]:
         """Get progress information for a scan session"""
         with SessionLocal() as session:
             scan_session = session.query(ScanSession).filter(ScanSession.id == session_id).first()
             if not scan_session:
                 return None
-            
+
             return ScanProgress(
                 session_id=scan_session.id,
                 session_type=scan_session.session_type,
                 accounts_processed=scan_session.accounts_processed,
                 total_accounts=scan_session.total_accounts,
                 current_cursor=scan_session.current_cursor,
-                started_at=scan_session.started_at
+                started_at=scan_session.started_at,
             )
-    
+
     def should_scan_account(self, account_id: str, account_data: Dict) -> bool:
         """Determine if an account needs scanning based on content changes"""
         content_hash = self._calculate_content_hash(account_data)
-        
+
         with SessionLocal() as session:
             # Check if we have a recent scan for this content
-            recent_scan = session.query(ContentScan).filter(
-                and_(
-                    ContentScan.mastodon_account_id == account_id,
-                    ContentScan.content_hash == content_hash,
-                    ContentScan.last_scanned_at > datetime.utcnow() - timedelta(hours=24),
-                    ContentScan.rules_version == self.rule_service.ruleset_sha256
+            recent_scan = (
+                session.query(ContentScan)
+                .filter(
+                    and_(
+                        ContentScan.mastodon_account_id == account_id,
+                        ContentScan.content_hash == content_hash,
+                        ContentScan.last_scanned_at > datetime.utcnow() - timedelta(hours=24),
+                        ContentScan.rules_version == self.rule_service.ruleset_sha256,
+                    )
                 )
-            ).first()
-            
+                .first()
+            )
+
             if recent_scan and not recent_scan.needs_rescan:
                 logger.debug(f"Skipping scan for {account_id} - content unchanged")
                 return False
-            
+
             return True
-    
+
     def scan_account_efficiently(self, account_data: Dict, session_id: int) -> Optional[Dict]:
         """Efficiently scan an account with deduplication and caching"""
         account_id = account_data.get("id")
         if not account_id:
             return None
-        
+
         # Check if we should scan this account
         if not self.should_scan_account(account_id, account_data):
             return None
-        
+
         content_hash = self._calculate_content_hash(account_data)
-        
+
         try:
             # Fetch statuses for analysis
             admin_client = MastoClient(self.settings.ADMIN_TOKEN)
             statuses = admin_client.get_account_statuses(
-                account_id=account_id,
-                limit=self.settings.MAX_STATUSES_TO_FETCH
+                account_id=account_id, limit=self.settings.MAX_STATUSES_TO_FETCH
             )
-            
-            # Evaluate account against rules
-            score, hits = self.rule_service.eval_account(account_data, statuses)
-            
-            # Store scan result
+
+            violations = self.rule_service.evaluate_account(account_data, statuses)
+            score = sum(v.score for v in violations)
+            hits = [(v.rule_name, v.score, v.evidence.dict()) for v in violations]
+
             scan_result = {
                 "score": score,
                 "hits": len(hits),
-                "rule_hits": [{"rule": hit[0], "weight": hit[1], "evidence": hit[2]} for hit in hits],
+                "rule_hits": [{"rule": h[0], "weight": h[1], "evidence": h[2]} for h in hits],
                 "scanned_at": datetime.utcnow().isoformat(),
-                "status_count": len(statuses)
+                "status_count": len(statuses),
             }
-            
+
             # Update content scan record
             with SessionLocal() as db_session:
-                content_scan = ContentScan(
-                    content_hash=content_hash,
-                    mastodon_account_id=account_id,
-                    scan_type='account',
-                    scan_result=scan_result,
-                    rules_version=self.rule_service.ruleset_sha256,
-                    needs_rescan=False
-                )
-                
-                # Use upsert to handle duplicates
                 stmt = pg_insert(ContentScan).values(
                     content_hash=content_hash,
                     mastodon_account_id=account_id,
-                    scan_type='account',
+                    scan_type="account",
                     scan_result=scan_result,
                     rules_version=self.rule_service.ruleset_sha256,
                     needs_rescan=False,
-                    last_scanned_at=func.now()
+                    last_scanned_at=func.now(),
                 )
                 stmt = stmt.on_conflict_do_update(
-                    index_elements=['content_hash'],
+                    index_elements=["content_hash"],
                     set_=dict(
                         scan_result=stmt.excluded.scan_result,
                         rules_version=stmt.excluded.rules_version,
                         last_scanned_at=func.now(),
-                        needs_rescan=False
-                    )
+                        needs_rescan=False,
+                    ),
                 )
                 db_session.execute(stmt)
-                
+
                 # Update session progress
                 scan_session = db_session.query(ScanSession).filter(ScanSession.id == session_id).first()
                 if scan_session:
                     scan_session.accounts_processed += 1
                     scan_session.last_account_id = account_id
-                
+
                 # Update account record
-                account_record = db_session.query(Account).filter(
-                    Account.mastodon_account_id == account_id
-                ).first()
+                account_record = db_session.query(Account).filter(Account.mastodon_account_id == account_id).first()
                 if account_record:
                     account_record.content_hash = content_hash
                     account_record.last_full_scan_at = datetime.utcnow()
-                
+
                 db_session.commit()
-            
+
             # Track domain-level violations if score is above threshold
             if score >= float(self.rule_service.get_config_value("report_threshold", 1.0)):
                 domain = self._extract_domain(account_data)
                 if domain and domain != "local":
                     self._track_domain_violation(domain)
-            
+
             return scan_result
-            
+
         except Exception as e:
             logger.error(f"Error scanning account {account_id}: {e}")
             return None
-    
-    def get_next_accounts_to_scan(self, session_type: str, limit: int = 50, cursor: Optional[str] = None) -> Tuple[List[Dict], Optional[str]]:
+
+    def get_next_accounts_to_scan(
+        self, session_type: str, limit: int = 50, cursor: Optional[str] = None
+    ) -> Tuple[List[Dict], Optional[str]]:
         """Get next batch of accounts to scan with cursor-based pagination"""
         try:
             admin_client = MastoClient(self.settings.ADMIN_TOKEN)
-            
-            params = {
-                "origin": session_type,  # 'local' or 'remote'
-                "status": "active",
-                "limit": limit
-            }
-            
+
+            params = {"origin": session_type, "status": "active", "limit": limit}  # 'local' or 'remote'
+
             if cursor:
                 params["max_id"] = cursor
-            
+
             accounts, next_cursor = admin_client.get_admin_accounts(
-                origin=session_type,
-                status="active",
-                limit=limit,
-                max_id=cursor
+                origin=session_type, status="active", limit=limit, max_id=cursor
             )
-            
+
             return accounts, next_cursor
-            
+
         except Exception as e:
             logger.error(f"Error fetching {session_type} accounts: {e}")
             return [], None
-    
+
     def scan_federated_content(self, domains: Optional[List[str]] = None) -> Dict[str, int]:
         """Scan content across federated domains"""
         session_id = self.start_scan_session("federated", {"target_domains": domains})
         results = {"scanned_domains": 0, "scanned_accounts": 0, "violations_found": 0}
-        
+
         try:
             # Get list of domains to scan
             target_domains = domains or self._get_active_domains()
-            
+
             for domain in target_domains:
                 domain_results = self._scan_domain_content(domain, session_id)
                 results["scanned_accounts"] += domain_results.get("accounts", 0)
                 results["violations_found"] += domain_results.get("violations", 0)
                 results["scanned_domains"] += 1
-                
+
                 # Check if domain should be defederated
                 self._check_defederation_threshold(domain)
-            
+
             self.complete_scan_session(session_id)
-            
+
         except Exception as e:
             logger.error(f"Error in federated scan: {e}")
-            self.complete_scan_session(session_id, 'failed')
-        
+            self.complete_scan_session(session_id, "failed")
+
         return results
-    
+
     def _scan_domain_content(self, domain: str, session_id: int) -> Dict[str, int]:
         """Scan content for a specific domain"""
         results = {"accounts": 0, "violations": 0}
-        
+
         with SessionLocal() as session:
             # Get accounts from this domain
             accounts = session.query(Account).filter(Account.domain == domain).limit(100).all()
-            
+
             for account in accounts:
                 try:
                     # Create account data structure for scanning
-                    account_data = {
-                        "id": account.mastodon_account_id,
-                        "acct": account.acct,
-                        "domain": account.domain
-                    }
-                    
+                    account_data = {"id": account.mastodon_account_id, "acct": account.acct, "domain": account.domain}
+
                     scan_result = self.scan_account_efficiently(account_data, session_id)
                     if scan_result:
                         results["accounts"] += 1
-                        if scan_result.get("score", 0) >= float(self.rule_service.get_config_value("report_threshold", 1.0)):
+                        if scan_result.get("score", 0) >= float(
+                            self.rule_service.get_config_value("report_threshold", 1.0)
+                        ):
                             results["violations"] += 1
-                
+
                 except Exception as e:
                     logger.error(f"Error scanning account {account.mastodon_account_id}: {e}")
-        
+
         return results
-    
+
     def _track_domain_violation(self, domain: str):
         """Track violations for domain-level defederation decisions"""
         with SessionLocal() as session:
             # Get or create domain alert record
-            stmt = pg_insert(DomainAlert).values(
-                domain=domain,
-                violation_count=1,
-                last_violation_at=func.now()
-            )
+            stmt = pg_insert(DomainAlert).values(domain=domain, violation_count=1, last_violation_at=func.now())
             stmt = stmt.on_conflict_do_update(
-                index_elements=['domain'],
-                set_=dict(
-                    violation_count=DomainAlert.violation_count + 1,
-                    last_violation_at=func.now()
-                )
+                index_elements=["domain"],
+                set_=dict(violation_count=DomainAlert.violation_count + 1, last_violation_at=func.now()),
             )
             session.execute(stmt)
             session.commit()
-    
+
     def _check_defederation_threshold(self, domain: str):
         """Check if domain should be defederated based on violation count"""
         with SessionLocal() as session:
             domain_alert = session.query(DomainAlert).filter(DomainAlert.domain == domain).first()
-            
+
             if domain_alert and not domain_alert.is_defederated:
                 if domain_alert.violation_count >= domain_alert.defederation_threshold:
                     # Mark for defederation (actual defederation would be a separate process)
@@ -316,11 +293,13 @@ class EnhancedScanningSystem:
                     domain_alert.defederated_at = datetime.utcnow()
                     domain_alert.defederated_by = "automated_system"
                     domain_alert.notes = f"Automatic defederation after {domain_alert.violation_count} violations"
-                    
+
                     session.commit()
-                    
-                    logger.warning(f"Domain {domain} marked for defederation after {domain_alert.violation_count} violations")
-    
+
+                    logger.warning(
+                        f"Domain {domain} marked for defederation after {domain_alert.violation_count} violations"
+                    )
+
     def _calculate_content_hash(self, account_data: Dict) -> str:
         """Calculate hash of account content for change detection"""
         # Include key fields that would indicate content changes
@@ -330,49 +309,48 @@ class EnhancedScanningSystem:
             "note": account_data.get("note", ""),
             "avatar": account_data.get("avatar", ""),
             "header": account_data.get("header", ""),
-            "fields": account_data.get("fields", [])
+            "fields": account_data.get("fields", []),
         }
-        
+
         content_str = str(sorted(content_fields.items()))
         return hashlib.sha256(content_str.encode()).hexdigest()
-    
+
     def _extract_domain(self, account_data: Dict) -> Optional[str]:
         """Extract domain from account data"""
         acct = account_data.get("acct", "")
         if "@" in acct:
             return acct.split("@")[-1]
         return "local"
-    
+
     def _get_current_rules_snapshot(self) -> Dict:
         """Get current rules configuration for session tracking"""
         rules_list, config, ruleset_sha256 = self.rule_service.get_active_rules()
         return {
             "rules_version": ruleset_sha256,
             "report_threshold": config.get("report_threshold", 1.0),
-            "rule_count": len(rules_list)
+            "rule_count": len(rules_list),
         }
-    
+
     def _get_active_domains(self) -> List[str]:
         """Get list of active domains for federated scanning"""
         with SessionLocal() as session:
-            domains = session.query(Account.domain).filter(
-                and_(
-                    Account.domain != "local",
-                    Account.last_checked_at > datetime.utcnow() - timedelta(days=30)
+            domains = (
+                session.query(Account.domain)
+                .filter(
+                    and_(Account.domain != "local", Account.last_checked_at > datetime.utcnow() - timedelta(days=30))
                 )
-            ).distinct().limit(50).all()
-            
+                .distinct()
+                .limit(50)
+                .all()
+            )
+
             return [domain[0] for domain in domains]
-    
-    
-    
+
     def get_domain_alerts(self, limit: int = 50) -> List[Dict]:
         """Get current domain alerts and defederation status"""
         with SessionLocal() as session:
-            alerts = session.query(DomainAlert).order_by(
-                desc(DomainAlert.violation_count)
-            ).limit(limit).all()
-            
+            alerts = session.query(DomainAlert).order_by(desc(DomainAlert.violation_count)).limit(limit).all()
+
             return [
                 {
                     "domain": alert.domain,
@@ -382,11 +360,11 @@ class EnhancedScanningSystem:
                     "is_defederated": alert.is_defederated,
                     "defederated_at": alert.defederated_at.isoformat() if alert.defederated_at else None,
                     "defederated_by": alert.defederated_by,
-                    "notes": alert.notes
+                    "notes": alert.notes,
                 }
                 for alert in alerts
             ]
-    
+
     def invalidate_content_scans(self, rule_changes: bool = False):
         """Mark content scans for re-scanning when rules change"""
         with SessionLocal() as session:
@@ -396,9 +374,7 @@ class EnhancedScanningSystem:
             else:
                 # Mark old scans as needing rescan
                 cutoff = datetime.utcnow() - timedelta(days=7)
-                session.query(ContentScan).filter(
-                    ContentScan.last_scanned_at < cutoff
-                ).update({"needs_rescan": True})
-            
+                session.query(ContentScan).filter(ContentScan.last_scanned_at < cutoff).update({"needs_rescan": True})
+
             session.commit()
             logger.info("Content scans marked for re-scanning")

--- a/tests/test_authentication_authorization.py
+++ b/tests/test_authentication_authorization.py
@@ -20,19 +20,21 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Set test environment before any imports
-os.environ.update({
-    "SKIP_STARTUP_VALIDATION": "1",
-    "INSTANCE_BASE": "https://test.mastodon.social",
-    "ADMIN_TOKEN": "test_admin_token_123456789",
-    "BOT_TOKEN": "test_bot_token_123456789",
-    "DATABASE_URL": "postgresql+psycopg://test:test@localhost:5433/mastowatch_test",
-    "REDIS_URL": "redis://localhost:6380/1",
-    "OAUTH_CLIENT_ID": "test_oauth_client_id",
-    "OAUTH_CLIENT_SECRET": "test_oauth_client_secret",
-    "SESSION_SECRET_KEY": "test_session_secret_key_123456789",
-    "OAUTH_REDIRECT_URI": "http://localhost:8080/admin/callback",
-    "OAUTH_POPUP_REDIRECT_URI": "http://localhost:8080/admin/popup-callback"
-})
+os.environ.update(
+    {
+        "SKIP_STARTUP_VALIDATION": "1",
+        "INSTANCE_BASE": "https://test.mastodon.social",
+        "ADMIN_TOKEN": "test_admin_token_123456789",
+        "BOT_TOKEN": "test_bot_token_123456789",
+        "DATABASE_URL": "postgresql+psycopg://test:test@localhost:5433/mastowatch_test",
+        "REDIS_URL": "redis://localhost:6380/1",
+        "OAUTH_CLIENT_ID": "test_oauth_client_id",
+        "OAUTH_CLIENT_SECRET": "test_oauth_client_secret",
+        "SESSION_SECRET_KEY": "test_session_secret_key_123456789",
+        "OAUTH_REDIRECT_URI": "http://localhost:8080/admin/callback",
+        "OAUTH_POPUP_REDIRECT_URI": "http://localhost:8080/admin/popup-callback",
+    }
+)
 
 # Add the app directory to the path so we can import the app modules
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -71,7 +73,12 @@ class TestAuthenticationAuthorization(unittest.TestCase):
         self.mock_jwt_instance = MagicMock()
         self.mock_jwt_config.return_value = self.mock_jwt_instance
 
+        self.rule_service_patcher = patch("app.main.rule_service")
+        self.mock_rule_service = self.rule_service_patcher.start()
+        self.mock_rule_service.evaluate_account.return_value = []
+
         from app.main import app
+
         self.app = app
         self.client = TestClient(app)
 
@@ -80,63 +87,65 @@ class TestAuthenticationAuthorization(unittest.TestCase):
         self.db_patcher.stop()
         self.oauth_patcher.stop()
         self.jwt_patcher.stop()
+        self.rule_service_patcher.stop()
 
     def create_test_admin_user(self):
         """Create test admin user"""
         from app.oauth import User
+
         return User(
             id="admin_123",
             username="testadmin",
             acct="testadmin@test.example",
             display_name="Test Admin",
             is_admin=True,
-            avatar=None
+            avatar=None,
         )
 
     def create_test_owner_user(self):
         """Create test owner user"""
         from app.oauth import User
+
         return User(
             id="owner_123",
             username="testowner",
             acct="testowner@test.example",
             display_name="Test Owner",
             is_admin=True,
-            avatar=None
+            avatar=None,
         )
 
     def create_test_moderator_user(self):
         """Create test moderator user"""
         from app.oauth import User
+
         return User(
             id="mod_123",
             username="testmod",
             acct="testmod@test.example",
             display_name="Test Moderator",
             is_admin=True,
-            avatar=None
+            avatar=None,
         )
 
     def create_test_regular_user(self):
         """Create test regular user"""
         from app.oauth import User
+
         return User(
             id="user_123",
             username="testuser",
             acct="testuser@test.example",
             display_name="Test User",
             is_admin=False,
-            avatar=None
+            avatar=None,
         )
 
     def create_valid_jwt_token(self, user_data):
         """Create a valid JWT token for testing"""
         secret = "test_session_secret_key_123456789"
         payload = user_data.copy()
-        payload.update({
-            "exp": datetime.utcnow() + timedelta(hours=24),
-            "iat": datetime.utcnow()
-        })
+        payload.update({"exp": datetime.utcnow() + timedelta(hours=24), "iat": datetime.utcnow()})
         return jwt.encode(payload, secret, algorithm="HS256")
 
     # ========== OAUTH AUTHENTICATION TESTS ==========
@@ -144,14 +153,14 @@ class TestAuthenticationAuthorization(unittest.TestCase):
     def test_oauth_login_initiation(self):
         """Test OAuth login flow initiation"""
         response = self.client.get("/admin/login")
-        
+
         # Should redirect to OAuth provider or return 302
         self.assertIn(response.status_code, [302, 200])
 
     def test_oauth_login_popup_mode(self):
         """Test OAuth login in popup mode"""
         response = self.client.get("/admin/login?popup=true")
-        
+
         # Should handle popup mode
         self.assertIn(response.status_code, [302, 200])
 
@@ -160,7 +169,7 @@ class TestAuthenticationAuthorization(unittest.TestCase):
         # Test callback without state
         response = self.client.get("/admin/callback?code=test_code")
         self.assertEqual(response.status_code, 400)
-        
+
         # Test callback with mismatched state
         response = self.client.get("/admin/callback?code=test_code&state=invalid_state")
         self.assertEqual(response.status_code, 400)
@@ -170,7 +179,7 @@ class TestAuthenticationAuthorization(unittest.TestCase):
         # Test error parameter in callback
         response = self.client.get("/admin/callback?error=access_denied")
         self.assertEqual(response.status_code, 400)
-        
+
         # Test missing authorization code
         response = self.client.get("/admin/callback?state=test_state")
         self.assertEqual(response.status_code, 400)
@@ -184,20 +193,20 @@ class TestAuthenticationAuthorization(unittest.TestCase):
         mock_response.status_code = 200
         mock_response.json.return_value = {"access_token": "test_access_token"}
         mock_http_client.post.return_value = mock_response
-        
+
         mock_client_instance = MagicMock()
         mock_client_instance.get_async_httpx_client.return_value.__aenter__.return_value = mock_http_client
         mock_client.return_value = mock_client_instance
-        
+
         # Mock user info fetch
         admin_user = self.create_test_admin_user()
         self.mock_oauth_instance.fetch_user_info.return_value = admin_user
-        
+
         # Mock state validation
         self.mock_redis_instance.get.return_value = "valid"
-        
+
         response = self.client.get("/admin/callback?code=test_code&state=test_state")
-        
+
         # Should successfully process callback
         self.assertIn(response.status_code, [200, 302])
 
@@ -206,7 +215,7 @@ class TestAuthenticationAuthorization(unittest.TestCase):
         # Mock user info fetch returning non-admin user
         regular_user = self.create_test_regular_user()
         self.mock_oauth_instance.fetch_user_info.return_value = regular_user
-        
+
         # Mock successful token exchange
         with patch("app.main.Client") as mock_client:
             mock_http_client = AsyncMock()
@@ -214,24 +223,24 @@ class TestAuthenticationAuthorization(unittest.TestCase):
             mock_response.status_code = 200
             mock_response.json.return_value = {"access_token": "test_access_token"}
             mock_http_client.post.return_value = mock_response
-            
+
             mock_client_instance = MagicMock()
             mock_client_instance.get_async_httpx_client.return_value.__aenter__.return_value = mock_http_client
             mock_client.return_value = mock_client_instance
-            
+
             # Mock state validation
             self.mock_redis_instance.get.return_value = "valid"
-            
+
             response = self.client.get("/admin/callback?code=test_code&state=test_state")
             self.assertEqual(response.status_code, 403)
 
     def test_oauth_not_configured(self):
         """Test OAuth endpoints when OAuth is not configured"""
         self.mock_oauth_instance.configured = False
-        
+
         response = self.client.get("/admin/login")
         self.assertEqual(response.status_code, 503)
-        
+
         response = self.client.get("/admin/callback")
         self.assertEqual(response.status_code, 503)
 
@@ -240,10 +249,10 @@ class TestAuthenticationAuthorization(unittest.TestCase):
     def test_jwt_token_creation(self):
         """Test JWT token creation"""
         user_data = self.create_test_admin_user().model_dump()
-        
+
         # Mock JWT config
         self.mock_jwt_instance.create_access_token.return_value = "test_jwt_token"
-        
+
         token = self.mock_jwt_instance.create_access_token(user_data)
         self.assertEqual(token, "test_jwt_token")
 
@@ -251,49 +260,35 @@ class TestAuthenticationAuthorization(unittest.TestCase):
         """Test JWT token validation"""
         admin_user = self.create_test_admin_user()
         user_data = admin_user.model_dump()
-        
-        # Create valid token
         token = self.create_valid_jwt_token(user_data)
-        
-        # Mock JWT verification
         self.mock_jwt_instance.verify_token.return_value = user_data
-        
+
         # Test token validation
-        response = self.client.get("/api/v1/me", headers={
-            "Authorization": f"Bearer {token}"
-        })
-        
+        response = self.client.get("/api/v1/me", headers={"Authorization": f"Bearer {token}"})
+
         # Should work with valid token
         self.assertIn(response.status_code, [200, 401])  # May depend on other mocks
 
     def test_jwt_token_expiration(self):
         """Test JWT token expiration handling"""
         from fastapi import HTTPException
-        
+
         # Mock expired token
-        self.mock_jwt_instance.verify_token.side_effect = HTTPException(
-            status_code=401, detail="Token has expired"
-        )
-        
-        response = self.client.get("/api/v1/me", headers={
-            "Authorization": "Bearer expired_token"
-        })
-        
+        self.mock_jwt_instance.verify_token.side_effect = HTTPException(status_code=401, detail="Token has expired")
+
+        response = self.client.get("/api/v1/me", headers={"Authorization": "Bearer expired_token"})
+
         self.assertEqual(response.status_code, 401)
 
     def test_jwt_invalid_token(self):
         """Test handling of invalid JWT tokens"""
         from fastapi import HTTPException
-        
+
         # Mock invalid token
-        self.mock_jwt_instance.verify_token.side_effect = HTTPException(
-            status_code=401, detail="Invalid token"
-        )
-        
-        response = self.client.get("/api/v1/me", headers={
-            "Authorization": "Bearer invalid_token"
-        })
-        
+        self.mock_jwt_instance.verify_token.side_effect = HTTPException(status_code=401, detail="Invalid token")
+
+        response = self.client.get("/api/v1/me", headers={"Authorization": "Bearer invalid_token"})
+
         self.assertEqual(response.status_code, 401)
 
     # ========== ROLE-BASED ACCESS CONTROL TESTS ==========
@@ -301,7 +296,7 @@ class TestAuthenticationAuthorization(unittest.TestCase):
     def test_admin_role_access(self):
         """Test that Admin role has access to admin endpoints"""
         admin_user = self.create_test_admin_user()
-        
+
         with patch("app.main.get_current_user_hybrid", return_value=admin_user):
             response = self.client.get("/analytics/overview")
             self.assertEqual(response.status_code, 200)
@@ -309,7 +304,7 @@ class TestAuthenticationAuthorization(unittest.TestCase):
     def test_owner_role_access(self):
         """Test that Owner role has access to admin endpoints"""
         owner_user = self.create_test_owner_user()
-        
+
         with patch("app.main.get_current_user_hybrid", return_value=owner_user):
             response = self.client.get("/analytics/overview")
             self.assertEqual(response.status_code, 200)
@@ -317,7 +312,7 @@ class TestAuthenticationAuthorization(unittest.TestCase):
     def test_moderator_role_access(self):
         """Test that Moderator role has access to admin endpoints"""
         mod_user = self.create_test_moderator_user()
-        
+
         with patch("app.main.get_current_user_hybrid", return_value=mod_user):
             response = self.client.get("/analytics/overview")
             self.assertEqual(response.status_code, 200)
@@ -325,7 +320,7 @@ class TestAuthenticationAuthorization(unittest.TestCase):
     def test_regular_user_access_denied(self):
         """Test that regular users are denied access to admin endpoints"""
         regular_user = self.create_test_regular_user()
-        
+
         with patch("app.main.get_current_user_hybrid", return_value=regular_user):
             response = self.client.get("/analytics/overview")
             self.assertEqual(response.status_code, 403)
@@ -341,32 +336,29 @@ class TestAuthenticationAuthorization(unittest.TestCase):
         # Test admin permission bit (bit 0 = value 1)
         with patch("app.oauth.OAuthConfig.fetch_user_info") as mock_fetch:
             # Mock role data with admin permission
-            mock_role_data = {
-                "id": "3",
-                "name": "Admin",
-                "permissions": "1"  # Binary: ...0001 (admin bit set)
-            }
-            
+            mock_role_data = {"id": "3", "name": "Admin", "permissions": "1"}  # Binary: ...0001 (admin bit set)
+
             mock_user_data = {
                 "id": "test_123",
                 "username": "testadmin",
                 "acct": "testadmin@test.example",
                 "display_name": "Test Admin",
-                "role": mock_role_data
+                "role": mock_role_data,
             }
-            
+
             # Should be recognized as admin
             from app.oauth import User
+
             expected_user = User(
                 id="test_123",
                 username="testadmin",
                 acct="testadmin@test.example",
                 display_name="Test Admin",
-                is_admin=True
+                is_admin=True,
             )
-            
+
             mock_fetch.return_value = expected_user
-            
+
             user = mock_fetch(mock_user_data)
             self.assertTrue(user.is_admin)
 
@@ -374,26 +366,27 @@ class TestAuthenticationAuthorization(unittest.TestCase):
         """Test fallback role validation by role name"""
         # Test role names that should grant admin access
         admin_roles = ["admin", "moderator", "owner", "Admin", "Moderator", "Owner"]
-        
+
         for role_name in admin_roles:
             with patch("app.oauth.OAuthConfig.fetch_user_info") as mock_fetch:
                 mock_role_data = {
                     "id": "3",
                     "name": role_name,
-                    "permissions": "0"  # No permission bits, should fall back to name
+                    "permissions": "0",  # No permission bits, should fall back to name
                 }
-                
+
                 from app.oauth import User
+
                 expected_user = User(
                     id="test_123",
                     username="testuser",
                     acct="testuser@test.example",
                     display_name="Test User",
-                    is_admin=True
+                    is_admin=True,
                 )
-                
+
                 mock_fetch.return_value = expected_user
-                
+
                 user = mock_fetch({"role": mock_role_data})
                 self.assertTrue(user.is_admin, f"Role '{role_name}' should grant admin access")
 
@@ -402,27 +395,24 @@ class TestAuthenticationAuthorization(unittest.TestCase):
     def test_hybrid_auth_jwt_priority(self):
         """Test that JWT authentication takes priority in hybrid mode"""
         admin_user = self.create_test_admin_user()
-        user_data = admin_user.model_dump()
-        
+
         # Mock JWT token validation
         with patch("app.jwt_auth.get_current_user_from_token", return_value=admin_user):
             with patch("app.oauth.get_current_user", return_value=None):  # No cookie
-                response = self.client.get("/api/v1/me", headers={
-                    "Authorization": "Bearer valid_jwt_token"
-                })
-                
+                response = self.client.get("/api/v1/me", headers={"Authorization": "Bearer valid_jwt_token"})
+
                 # Should use JWT authentication
                 self.assertIn(response.status_code, [200, 401])
 
     def test_hybrid_auth_cookie_fallback(self):
         """Test that cookie authentication is used as fallback"""
         admin_user = self.create_test_admin_user()
-        
+
         # Mock failed JWT (no token) but valid cookie
         with patch("app.jwt_auth.get_current_user_from_token", return_value=None):
             with patch("app.oauth.get_current_user", return_value=admin_user):
                 response = self.client.get("/api/v1/me")
-                
+
                 # Should use cookie authentication
                 self.assertIn(response.status_code, [200, 401])
 
@@ -432,7 +422,7 @@ class TestAuthenticationAuthorization(unittest.TestCase):
         with patch("app.jwt_auth.get_current_user_from_token", return_value=None):
             with patch("app.oauth.get_current_user", return_value=None):
                 response = self.client.get("/api/v1/me")
-                
+
                 # Should deny access
                 self.assertEqual(response.status_code, 401)
 
@@ -441,7 +431,7 @@ class TestAuthenticationAuthorization(unittest.TestCase):
     def test_session_cookie_creation(self):
         """Test session cookie creation"""
         admin_user = self.create_test_admin_user()
-        
+
         # Mock successful OAuth callback with cookie creation
         with patch("app.main.create_session_cookie") as mock_create_cookie:
             with patch("app.main.Client") as mock_client:
@@ -451,17 +441,17 @@ class TestAuthenticationAuthorization(unittest.TestCase):
                 mock_response.status_code = 200
                 mock_response.json.return_value = {"access_token": "test_token"}
                 mock_http_client.post.return_value = mock_response
-                
+
                 mock_client_instance = MagicMock()
                 mock_client_instance.get_async_httpx_client.return_value.__aenter__.return_value = mock_http_client
                 mock_client.return_value = mock_client_instance
-                
+
                 # Mock user fetch and state validation
                 self.mock_oauth_instance.fetch_user_info.return_value = admin_user
                 self.mock_redis_instance.get.return_value = "valid"
-                
+
                 response = self.client.get("/admin/callback?code=test_code&state=test_state")
-                
+
                 # Should create session cookie for non-popup mode
                 if response.status_code == 302:  # Redirect mode
                     mock_create_cookie.assert_called_once()
@@ -469,7 +459,7 @@ class TestAuthenticationAuthorization(unittest.TestCase):
     def test_session_logout(self):
         """Test session logout and cleanup"""
         response = self.client.post("/admin/logout")
-        
+
         # Should clear session
         self.assertEqual(response.status_code, 200)
 
@@ -477,10 +467,10 @@ class TestAuthenticationAuthorization(unittest.TestCase):
         """Test session cookie validation"""
         # Mock cookie-based authentication
         admin_user = self.create_test_admin_user()
-        
+
         with patch("app.oauth.get_current_user", return_value=admin_user):
             response = self.client.get("/api/v1/me")
-            
+
             # Should validate session cookie
             self.assertIn(response.status_code, [200, 401])
 
@@ -495,51 +485,42 @@ class TestAuthenticationAuthorization(unittest.TestCase):
             "/config/panic_stop",
             "/rules",
             "/scanning/federated",
-            "/analytics/domains"
+            "/analytics/domains",
         ]
-        
+
         for endpoint in admin_endpoints:
             # Test unauthenticated access
             if endpoint in ["/config/dry_run", "/config/panic_stop", "/rules", "/scanning/federated"]:
                 response = self.client.post(endpoint, json={})
             else:
                 response = self.client.get(endpoint)
-            
-            self.assertIn(response.status_code, [401, 403], 
-                         f"Endpoint {endpoint} should require authentication")
+
+            self.assertIn(response.status_code, [401, 403], f"Endpoint {endpoint} should require authentication")
 
     def test_public_endpoints(self):
         """Test that public endpoints are accessible"""
-        public_endpoints = [
-            "/healthz",
-            "/metrics",
-            "/dryrun/evaluate"
-        ]
-        
+        public_endpoints = ["/healthz", "/metrics", "/dryrun/evaluate"]
+
         for endpoint in public_endpoints:
             if endpoint == "/dryrun/evaluate":
                 response = self.client.post(endpoint, json={})
             else:
                 response = self.client.get(endpoint)
-            
-            self.assertEqual(response.status_code, 200, 
-                           f"Public endpoint {endpoint} should be accessible")
+
+            self.assertEqual(response.status_code, 200, f"Public endpoint {endpoint} should be accessible")
 
     def test_webhook_authentication(self):
         """Test webhook signature-based authentication"""
         payload = json.dumps({"account": {"id": "123"}, "statuses": []})
         secret = "test_webhook_secret_123"
         signature = hmac.new(secret.encode(), payload.encode(), hashlib.sha256).hexdigest()
-        
+
         response = self.client.post(
             "/webhooks/status",
             content=payload,
-            headers={
-                "X-Hub-Signature-256": f"sha256={signature}",
-                "Content-Type": "application/json"
-            }
+            headers={"X-Hub-Signature-256": f"sha256={signature}", "Content-Type": "application/json"},
         )
-        
+
         # Should authenticate with valid signature
         self.assertEqual(response.status_code, 200)
 
@@ -547,14 +528,12 @@ class TestAuthenticationAuthorization(unittest.TestCase):
         """Test API key authentication for config endpoints"""
         # Mock admin user for API key auth
         admin_user = self.create_test_admin_user()
-        
+
         with patch("app.main.get_current_user_hybrid", return_value=admin_user):
             response = self.client.post(
-                "/config/dry_run",
-                json={"dry_run": True},
-                headers={"X-API-Key": "test_api_key_123"}
+                "/config/dry_run", json={"dry_run": True}, headers={"X-API-Key": "test_api_key_123"}
             )
-            
+
             # Should work with valid API key and admin user
             self.assertEqual(response.status_code, 200)
 
@@ -570,11 +549,11 @@ class TestAuthenticationAuthorization(unittest.TestCase):
         """Test protection against token replay attacks"""
         # OAuth state should be single-use
         self.mock_redis_instance.get.return_value = "valid"
-        
+
         # First use should work (mocked)
         # Second use should fail (state consumed)
         self.mock_redis_instance.get.return_value = None
-        
+
         response = self.client.get("/admin/callback?code=test&state=used_state")
         self.assertEqual(response.status_code, 400)
 
@@ -588,14 +567,10 @@ class TestAuthenticationAuthorization(unittest.TestCase):
         """Test JWT security properties"""
         admin_user = self.create_test_admin_user()
         user_data = admin_user.model_dump()
-        
+
         # JWT should include expiration
-        token_data = {
-            **user_data,
-            "exp": datetime.utcnow() + timedelta(hours=24),
-            "iat": datetime.utcnow()
-        }
-        
+        token_data = {**user_data, "exp": datetime.utcnow() + timedelta(hours=24), "iat": datetime.utcnow()}
+
         # Verify required claims are present
         self.assertIn("exp", token_data)
         self.assertIn("iat", token_data)


### PR DESCRIPTION
## Summary
- remove legacy `eval_account` and `get_current_rules_snapshot`
- call `evaluate_account` directly in dry-run endpoint and internal services
- rewrite tests for new rule evaluation API

## Testing
- `make lint` *(fails: tests/test_cache.py:65:69: E712 comparison to True should be 'if cond is True:' or 'if cond:'; tests/test_cache.py:78:59: E712 comparison to False should be 'if cond is False:' or 'if not cond:'; tests/test_cache.py:92:1: C901 'mock_get_db_session' is too complex (14); tests/test_config.py:9:1: E402 module level import not at top of file; tests/test_domain_validation_monitoring.py:35:1: E402 module level import not at top of file; tests/test_domain_validation_monitoring.py:380:9: F841 local variable 'mock_overview' is assigned to but never used; tests/test_services.py:74:9: F841 local variable 'first_call_time' is assigned to but never used; tests/test_services.py:79:9: F841 local variable 'second_call_time' is assigned to but never used; tests/test_utils.py:13:30: W291 trailing whitespace; tests/test_utils.py:26:38: W291 trailing whitespace; tests/test_utils.py:36:11: W291 trailing whitespace; 11    C901 'admin_callback' is too complex (11); 9     E402 module level import not at top of file; 761   E501 line too long (129 > 127 characters); 6     E712 comparison to True should be 'if cond is True:' or 'if cond:'; 7     F841 local variable 'last_7d' is assigned to but never used; 7     W291 trailing whitespace; 12    W293 blank line contains whitespace; 7     W605 invalid escape sequence '\d')`
- `make typecheck` *(fails: app/config.py: error: Source file found twice under different module names: "config" and "app.config")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.clients.mastodon.client')*

------
https://chatgpt.com/codex/tasks/task_e_68913044eb388322890b84eccc09ca43