### PR TITLE
feat: expose configurable version

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,7 @@ DRY_RUN=true
 MAX_PAGES_PER_POLL=3
 MAX_STATUSES_TO_FETCH=100
 BATCH_SIZE=20
-USER_AGENT=MastoWatch/1.0 (+moderation-sidecar)
+USER_AGENT=MastoWatch/0.1.0 (+moderation-sidecar)
 POLICY_VERSION=v1
 REPORT_CATEGORY_DEFAULT=spam         # spam | violation | legal | other
 FORWARD_REMOTE_REPORTS=false
@@ -40,6 +40,7 @@ UI_ORIGIN=http://localhost:5173
 VITE_API_URL=http://localhost:8080
 
 # ----- Version & Scheduling -----
+VERSION=0.1.0
 MIN_MASTODON_VERSION=4.0.0
 POLL_ADMIN_ACCOUNTS_INTERVAL=30
 POLL_ADMIN_ACCOUNTS_LOCAL_INTERVAL=30

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Set these in `.env` (copied from `.env.example`):
 * `DRY_RUN`: `true` to log without sending reports (default: `false`)
 * `PANIC_STOP`: `true` to halt all processing (default: `false`)
 * `MAX_PAGES_PER_POLL`: admin polling pages per batch (default: 3)
+* `USER_AGENT`: user agent for Mastodon requests (default: `MastoWatch/<VERSION> (+moderation-sidecar)`)
+* `VERSION`: application version (default: `0.1.0`)
 * `SKIP_STARTUP_VALIDATION`: `true` to skip startup checks (for testing only)
 * `UI_ORIGIN`: origin for the dashboard UI
 * `MIN_MASTODON_VERSION`: minimum supported Mastodon version (default: `4.0.0`)

--- a/app/config.py
+++ b/app/config.py
@@ -4,8 +4,11 @@ from pydantic import AnyUrl, Field
 from pydantic_settings import BaseSettings
 
 
+APP_VERSION = "0.1.0"
+
+
 class Settings(BaseSettings):
-    VERSION: str = "0.1.0"
+    VERSION: str = APP_VERSION
     INSTANCE_BASE: AnyUrl
     BOT_TOKEN: str = Field(..., min_length=1)
     ADMIN_TOKEN: str = Field(..., min_length=1)
@@ -13,7 +16,7 @@ class Settings(BaseSettings):
     REDIS_URL: str = Field(..., min_length=1)
     DRY_RUN: bool = True
     MAX_PAGES_PER_POLL: int = 3
-    USER_AGENT: str = "MastoWatch/1.0 (+moderation-sidecar)"
+    USER_AGENT: str = f"MastoWatch/{APP_VERSION} (+moderation-sidecar)"
     MAX_STATUSES_TO_FETCH: int = 5
     BATCH_SIZE: int = 20
 

--- a/app/main.py
+++ b/app/main.py
@@ -28,12 +28,11 @@ from app.tasks.jobs import process_new_report, process_new_status
 
 setup_logging()
 logger = logging.getLogger(__name__)
+settings = get_settings()
 
-# Run startup validations before anything else
 run_all_startup_validations()
 
-app = FastAPI(title="MastoWatch", version="1.0.0")
-settings = get_settings()
+app = FastAPI(title="MastoWatch", version=settings.VERSION)
 
 # Add session middleware for OAuth2 flow (uses SESSION_SECRET_KEY from settings)
 if settings.SESSION_SECRET_KEY:


### PR DESCRIPTION
## Summary
- expose app version via configuration and reuse for user agent
- wire FastAPI version to settings
- document VERSION and updated sample env

## Testing
- `make format`
- `make lint` *(fails: E402 module level import not at top of file, F841 local variable assigned to but never used, W291 trailing whitespace, C901 too complex, E303 too many blank lines, E501 line too long, E712 comparison to True should be 'if cond is True:' or 'if cond:', F841 local variable 'last_7d' is assigned to but never used, W293 blank line contains whitespace, W605 invalid escape sequence '\\d')*
- `make typecheck` *(fails: SyntaxWarning invalid escape sequence '\\d', SyntaxWarning invalid escape sequence '\\.', make: *** [Makefile:67: typecheck] Error 2)*
- `pytest` *(fails: AttributeError module 'app.scanning' has no attribute..., sqlalchemy.exc.IntegrityError..., TypeError EnforcementService.__init__() missing..., 118 failed, 15 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689134aa352883228074364efa16caa0