### PR TITLE
fix: resolve mypy duplicate module error

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -42,9 +42,9 @@ jobs:
       run: |
         black --check --diff app tests || true
         
-    - name: Type check with mypy (main modules only)
+    - name: Type check with mypy
       run: |
-        mypy app/main.py app/config.py app/oauth.py --ignore-missing-imports
+        mypy app --explicit-package-bases --ignore-missing-imports
         
     - name: Security check with bandit
       run: |


### PR DESCRIPTION
## Summary
- add package marker for `app`
- run mypy on `app` with explicit package bases

## Testing
- `mypy app --explicit-package-bases --ignore-missing-imports` *(fails: Found 306 errors)*
- `python -m unittest discover tests` *(fails: failures=1, errors=89)*

------
https://chatgpt.com/codex/tasks/task_e_6891381142a883229b733dbb081bec29