### PR TITLE
feat(oauth): centralize admin token exchange

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -64,6 +64,7 @@ make help          # See all available commands
    - `OAUTH_CLIENT_ID`: OAuth application client ID
    - `OAUTH_CLIENT_SECRET`: OAuth application client secret
    - `OAUTH_REDIRECT_URI`: OAuth callback URL (e.g., `http://localhost:8000/admin/callback` for dev)
+   - `OAUTH_SCOPE`: OAuth scopes for admin login (default: `read:accounts`)
    - `SESSION_SECRET_KEY`: Random secret for session cookies (generate with `openssl rand -base64 32`)
 
 ### Development Settings

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Set these in `.env` (copied from `.env.example`):
 * `OAUTH_CLIENT_ID`: OAuth application client ID
 * `OAUTH_CLIENT_SECRET`: OAuth application client secret
 * `OAUTH_REDIRECT_URI`: OAuth callback URL (e.g., `https://your.instance/admin/callback`)
+* `OAUTH_SCOPE`: OAuth scopes for admin login (default: `read:accounts`)
 * `SESSION_SECRET_KEY`: Random secret for session cookies
 
 ### Optional Settings

--- a/app/config.py
+++ b/app/config.py
@@ -40,6 +40,7 @@ class Settings(BaseSettings):
     OAUTH_CLIENT_ID: str | None = None
     OAUTH_CLIENT_SECRET: str | None = None
     OAUTH_REDIRECT_URI: str | None = None
+    OAUTH_SCOPE: str = "read:accounts"
     OAUTH_POPUP_REDIRECT_URI: str | None = None
     SESSION_SECRET_KEY: str | None = None
     SESSION_COOKIE_NAME: str = "mastowatch_session"


### PR DESCRIPTION
## Summary
- add OAuth token exchange and credential verification to MastoClient
- surface OAuth scope in settings and docs
- route admin OAuth flow through MastoClient

## Testing
- `make lint` *(fails: tests/test_cache.py:52:64: E712 comparison to True should be 'if cond is True:' or 'if cond:')*
- `make typecheck` *(fails: app/config.py: error: Source file found twice under different module names: "config" and "app.config")*
- `pytest` *(fails: tests/test_domain_validation_monitoring.py::TestDomainValidationMonitoring::test_job_tracking_progress_monitoring - AttributeError: ...)*

------
https://chatgpt.com/codex/tasks/task_e_6891adf139188322aa029fab98970eb1