### PR TITLE
feat(config): add service layer for app config

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,9 @@ Endpoints:
 * `GET /metrics` - Prometheus metrics for monitoring
 
 #### Configuration Management (requires admin login)
-* `POST /config/dry_run` - Toggle dry run mode (body: `{"dry_run": true|false, "updated_by": "optional-string"}`)
-* `POST /config/panic_stop` - Emergency stop all processing (body: `{"panic_stop": true|false, "updated_by": "optional-string"}`)
+* `GET /config` - Return non-sensitive configuration details
+* `POST /config/dry_run?enable=true|false` - Toggle dry run mode
+* `POST /config/panic_stop?enable=true|false` - Emergency stop all processing
 
 #### Rule Management (requires admin login)
 * `GET /rules` - List all rules

--- a/app/api/config.py
+++ b/app/api/config.py
@@ -1,63 +1,81 @@
+"""Configuration management API routes."""
+
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy import text
 
 from app.auth import require_api_key
 from app.config import get_settings
-from app.db import SessionLocal
 from app.oauth import User, require_admin_hybrid
+from app.services.config_service import ConfigService, get_config_service
 
 router = APIRouter()
 
+api_key_dep = Depends(require_api_key)
+admin_dep = Depends(require_admin_hybrid)
+service_dep = Depends(get_config_service)
+MAX_THRESHOLD = 10
+
 
 @router.get("/config", response_model=dict[str, Any])
-async def get_app_config(api_key_valid: bool = Depends(require_api_key)):
-    """Get current application configuration."""
+async def get_app_config(
+    api_key_valid: bool = api_key_dep,
+    service: ConfigService = service_dep,
+):
+    """Return non-sensitive configuration values."""
     settings = get_settings()
-    return settings.dict()
+    allowed = {
+        "VERSION",
+        "DRY_RUN",
+        "PANIC_STOP",
+        "REPORT_CATEGORY_DEFAULT",
+        "FORWARD_REMOTE_REPORTS",
+        "MAX_PAGES_PER_POLL",
+        "MAX_STATUSES_TO_FETCH",
+    }
+    config: dict[str, Any] = {k: getattr(settings, k) for k in allowed}
+    panic_stop = service.get_config("panic_stop")
+    if panic_stop:
+        config["PANIC_STOP"] = panic_stop.get("enabled", config["PANIC_STOP"])
+    dry_run = service.get_config("dry_run")
+    if dry_run:
+        config["DRY_RUN"] = dry_run.get("enabled", config["DRY_RUN"])
+    report_threshold = service.get_config("report_threshold")
+    if report_threshold:
+        config["REPORT_THRESHOLD"] = report_threshold.get("threshold")
+    return config
 
 
 @router.post("/config/panic_stop", status_code=status.HTTP_200_OK)
-def set_panic_stop(enable: bool, _: User = Depends(require_admin_hybrid)):
-    """Enable or disable panic stop."""
-    with SessionLocal() as db:
-        db.execute(
-            text(
-                "INSERT INTO config (key, value) VALUES (:key, :value) ON CONFLICT (key) DO UPDATE SET value = :value"
-            ),
-            {"key": "panic_stop", "value": {"enabled": enable}},
-        )
-        db.commit()
-    return {"message": f"Panic stop set to {enable}"}
+def set_panic_stop(
+    enable: bool,
+    user: User = admin_dep,
+    service: ConfigService = service_dep,
+):
+    """Toggle panic stop flag."""
+    service.set_flag("panic_stop", enable, updated_by=user.username)
+    return {"panic_stop": enable}
 
 
 @router.post("/config/dry_run", tags=["ops"])
-def set_dry_run_mode(enable: bool, _: User = Depends(require_admin_hybrid)):
-    """Enable or disable dry run mode"""
-    with SessionLocal() as db:
-        db.execute(
-            text(
-                "INSERT INTO config (key, value) VALUES (:key, :value) ON CONFLICT (key) DO UPDATE SET value = :value"
-            ),
-            {"key": "dry_run", "value": {"enabled": enable}},
-        )
-        db.commit()
-    return {"message": f"Dry run mode set to {enable}"}
+def set_dry_run_mode(
+    enable: bool,
+    user: User = admin_dep,
+    service: ConfigService = service_dep,
+):
+    """Toggle dry run mode."""
+    service.set_flag("dry_run", enable, updated_by=user.username)
+    return {"dry_run": enable}
 
 
 @router.post("/config/report_threshold", tags=["ops"])
-def set_report_threshold(threshold: float, _: User = Depends(require_admin_hybrid)):
-    """Set the report threshold for automatic reporting"""
-    if threshold < 0 or threshold > 10:
+def set_report_threshold(
+    threshold: float,
+    user: User = admin_dep,
+    service: ConfigService = service_dep,
+):
+    """Update report threshold."""
+    if threshold < 0 or threshold > MAX_THRESHOLD:
         raise HTTPException(status_code=400, detail="Threshold must be between 0 and 10")
-
-    with SessionLocal() as db:
-        db.execute(
-            text(
-                "INSERT INTO config (key, value) VALUES (:key, :value) ON CONFLICT (key) DO UPDATE SET value = :value"
-            ),
-            {"key": "report_threshold", "value": {"threshold": threshold}},
-        )
-        db.commit()
-    return {"message": f"Report threshold set to {threshold}"}
+    service.set_threshold("report_threshold", threshold, updated_by=user.username)
+    return {"report_threshold": threshold}

--- a/app/services/config_service.py
+++ b/app/services/config_service.py
@@ -1,0 +1,48 @@
+"""Database-backed configuration helpers."""
+
+from typing import Any
+
+from app.db import SessionLocal
+from app.models import Config
+
+
+class ConfigService:
+    """CRUD operations for application configuration."""
+
+    def get_config(self, key: str) -> Any | None:
+        """Return configuration value for key."""
+        with SessionLocal() as session:
+            row = session.get(Config, key)
+            return row.value if row else None
+
+    def set_flag(self, key: str, enabled: bool, updated_by: str | None = None) -> dict[str, bool]:
+        """Store boolean flag in configuration."""
+        with SessionLocal() as session:
+            config = session.get(Config, key)
+            if config:
+                config.value = {"enabled": enabled}
+                config.updated_by = updated_by
+            else:
+                session.add(Config(key=key, value={"enabled": enabled}, updated_by=updated_by))
+            session.commit()
+            return {"enabled": enabled}
+
+    def set_threshold(self, key: str, threshold: float, updated_by: str | None = None) -> dict[str, float]:
+        """Store numeric threshold in configuration."""
+        with SessionLocal() as session:
+            config = session.get(Config, key)
+            if config:
+                config.value = {"threshold": threshold}
+                config.updated_by = updated_by
+            else:
+                session.add(Config(key=key, value={"threshold": threshold}, updated_by=updated_by))
+            session.commit()
+            return {"threshold": threshold}
+
+
+config_service = ConfigService()
+
+
+def get_config_service() -> ConfigService:
+    """Return ConfigService instance."""
+    return config_service

--- a/tests/services/test_config_service.py
+++ b/tests/services/test_config_service.py
@@ -1,0 +1,47 @@
+"""Tests for configuration service layer."""
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.db import Base
+from app.services.config_service import ConfigService
+
+
+class TestConfigService(unittest.TestCase):
+    """Validate ConfigService behavior."""
+
+    def setUp(self):
+        """Configure test database."""
+        self.db_file = tempfile.NamedTemporaryFile(delete=False, suffix=".db")
+        engine = create_engine(f"sqlite:///{self.db_file.name}")
+        Base.metadata.create_all(engine)
+        self.SessionLocal = sessionmaker(bind=engine)
+        self.service = ConfigService()
+        self.patcher = patch("app.services.config_service.SessionLocal", self.SessionLocal)
+        self.patcher.start()
+
+    def tearDown(self):
+        """Cleanup test database."""
+        self.patcher.stop()
+        os.unlink(self.db_file.name)
+
+    def test_set_and_get_flag(self):
+        """Store and retrieve flag value."""
+        self.service.set_flag("panic_stop", True, updated_by="tester")
+        value = self.service.get_config("panic_stop")
+        self.assertEqual(value["enabled"], True)
+
+    def test_set_threshold(self):
+        """Store and retrieve numeric threshold."""
+        self.service.set_threshold("report_threshold", 2.5, updated_by="tester")
+        value = self.service.get_config("report_threshold")
+        self.assertEqual(value["threshold"], 2.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,8 @@
+"""API endpoint integration tests."""
+
+import hashlib
+import hmac
+import json
 import os
 import sys
 import unittest
@@ -27,7 +32,7 @@ from app.oauth import User
 
 
 def create_mock_admin_user():
-    """Create a mock admin user for testing"""
+    """Create a mock admin user for testing."""
     return User(
         id="test_user_123",
         username="testadmin",
@@ -39,8 +44,10 @@ def create_mock_admin_user():
 
 
 class TestAPIEndpoints(unittest.TestCase):
+    """Integration tests for API endpoints."""
+
     def setUp(self):
-        # Mock external dependencies at import time
+        """Prepare test client with mocked dependencies."""
         with patch("redis.from_url") as mock_redis, patch("app.db.SessionLocal") as mock_db:
             mock_redis_instance = MagicMock()
             mock_redis.return_value = mock_redis_instance
@@ -50,8 +57,7 @@ class TestAPIEndpoints(unittest.TestCase):
             mock_db.return_value.__enter__.return_value = mock_session
             mock_session.execute.return_value = None
 
-            # Import app after setting up mocks
-            from app.main import app
+            from app.main import app  # noqa: PLC0415
 
             self.app = app
             self.client = TestClient(app)
@@ -70,11 +76,12 @@ class TestAPIEndpoints(unittest.TestCase):
         self.mock_session.execute.return_value = None
 
     def tearDown(self):
+        """Stop patched dependencies."""
         self.redis_patcher.stop()
         self.db_patcher.stop()
 
     def test_healthz_endpoint(self):
-        """Test that the health check endpoint returns proper status"""
+        """Test that the health check endpoint returns proper status."""
         response = self.client.get("/healthz")
         self.assertEqual(response.status_code, 200)
         data = response.json()
@@ -85,36 +92,69 @@ class TestAPIEndpoints(unittest.TestCase):
         self.assertIn("panic_stop", data)
 
     def test_metrics_endpoint(self):
-        """Test that metrics endpoint returns Prometheus format"""
+        """Test that metrics endpoint returns Prometheus format."""
         response = self.client.get("/metrics")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers["content-type"], "text/plain; charset=utf-8")
 
     # NEW API ROUTER TESTS
 
-    @patch("app.api.config.require_admin")
-    def test_dry_run_toggle_new_endpoint(self, mock_auth):
-        """Test dry run configuration endpoint with new API structure"""
+    @patch("app.api.config.get_config_service")
+    @patch("app.api.config.require_admin_hybrid")
+    def test_dry_run_toggle_new_endpoint(self, mock_auth, mock_service):
+        """Toggle dry run via service."""
         mock_auth.return_value = create_mock_admin_user()
+        service = MagicMock()
+        mock_service.return_value = service
+        response = self.client.post("/api/v1/config/dry_run?enable=false")
+        self.assertEqual(response.status_code, 200)
+        service.set_flag.assert_called_once_with("dry_run", False, updated_by="testadmin")
 
-        response = self.client.post("/api/v1/config/dry_run", json={"dry_run": False, "updated_by": "test_user"})
+    @patch("app.api.config.get_config_service")
+    @patch("app.api.config.require_admin_hybrid")
+    def test_panic_stop_toggle_new_endpoint(self, mock_auth, mock_service):
+        """Toggle panic stop via service."""
+        mock_auth.return_value = create_mock_admin_user()
+        service = MagicMock()
+        mock_service.return_value = service
+        response = self.client.post("/api/v1/config/panic_stop?enable=true")
+        self.assertEqual(response.status_code, 200)
+        service.set_flag.assert_called_once_with("panic_stop", True, updated_by="testadmin")
+
+    @patch("app.api.config.get_config_service")
+    @patch("app.api.config.require_admin_hybrid")
+    def test_report_threshold_uses_service(self, mock_auth, mock_service):
+        """Update report threshold via service."""
+        mock_auth.return_value = create_mock_admin_user()
+        service = MagicMock()
+        mock_service.return_value = service
+        response = self.client.post("/api/v1/config/report_threshold?threshold=2.5")
+        self.assertEqual(response.status_code, 200)
+        service.set_threshold.assert_called_once_with("report_threshold", 2.5, updated_by="testadmin")
+
+    @patch("app.api.config.get_config_service")
+    def test_get_config_returns_non_sensitive_fields(self, mock_service):
+        """Expose only safe configuration."""
+        service = MagicMock()
+        service.get_config.side_effect = lambda key: {
+            "panic_stop": {"enabled": True},
+            "dry_run": {"enabled": False},
+            "report_threshold": {"threshold": 2.5},
+        }.get(key)
+        mock_service.return_value = service
+        headers = {"X-API-Key": os.environ["API_KEY"]}
+        response = self.client.get("/api/v1/config", headers=headers)
         self.assertEqual(response.status_code, 200)
         data = response.json()
-        self.assertIn("dry_run", data)
-
-    @patch("app.api.config.require_admin")
-    def test_panic_stop_toggle_new_endpoint(self, mock_auth):
-        """Test panic stop configuration endpoint with new API structure"""
-        mock_auth.return_value = create_mock_admin_user()
-
-        response = self.client.post("/api/v1/config/panic_stop", json={"panic_stop": True, "updated_by": "test_user"})
-        self.assertEqual(response.status_code, 200)
-        data = response.json()
-        self.assertIn("panic_stop", data)
+        self.assertNotIn("ADMIN_TOKEN", data)
+        self.assertNotIn("BOT_TOKEN", data)
+        self.assertIn("DRY_RUN", data)
+        self.assertEqual(data["PANIC_STOP"], True)
+        self.assertEqual(data["REPORT_THRESHOLD"], 2.5)
 
     @patch("app.api.analytics.require_admin")
     def test_analytics_overview_new_endpoint(self, mock_auth):
-        """Test analytics overview endpoint with new API structure"""
+        """Test analytics overview endpoint with new API structure."""
         mock_auth.return_value = create_mock_admin_user()
 
         response = self.client.get("/api/v1/analytics/overview")
@@ -125,7 +165,7 @@ class TestAPIEndpoints(unittest.TestCase):
 
     @patch("app.api.analytics.require_admin")
     def test_analytics_timeline_new_endpoint(self, mock_auth):
-        """Test analytics timeline endpoint with new API structure"""
+        """Test analytics timeline endpoint with new API structure."""
         mock_auth.return_value = create_mock_admin_user()
 
         response = self.client.get("/api/v1/analytics/timeline?days=7")
@@ -136,7 +176,7 @@ class TestAPIEndpoints(unittest.TestCase):
 
     @patch("app.api.rules.require_admin")
     def test_get_current_rules_new_endpoint(self, mock_auth):
-        """Test current rules endpoint with new API structure"""
+        """Test current rules endpoint with new API structure."""
         mock_auth.return_value = create_mock_admin_user()
 
         with patch("app.api.rules.rule_service") as mock_rule_service:
@@ -150,7 +190,7 @@ class TestAPIEndpoints(unittest.TestCase):
 
     @patch("app.api.rules.require_admin")
     def test_create_rule_new_endpoint(self, mock_auth):
-        """Test creating a new rule via API"""
+        """Test creating a new rule via API."""
         mock_auth.return_value = create_mock_admin_user()
 
         with patch("app.api.rules.rule_service") as mock_rule_service:
@@ -178,7 +218,7 @@ class TestAPIEndpoints(unittest.TestCase):
 
     @patch("app.api.rules.require_admin")
     def test_update_rule_new_endpoint(self, mock_auth):
-        """Test updating a rule via API"""
+        """Test updating a rule via API."""
         mock_auth.return_value = create_mock_admin_user()
 
         with patch("app.api.rules.rule_service") as mock_rule_service:
@@ -198,7 +238,7 @@ class TestAPIEndpoints(unittest.TestCase):
 
     @patch("app.api.rules.require_admin")
     def test_delete_rule_new_endpoint(self, mock_auth):
-        """Test deleting a rule via API"""
+        """Test deleting a rule via API."""
         mock_auth.return_value = create_mock_admin_user()
 
         with patch("app.api.rules.rule_service") as mock_rule_service:
@@ -214,85 +254,62 @@ class TestAPIEndpoints(unittest.TestCase):
 
     @patch("app.main.process_new_report")
     def test_webhook_report_created(self, mock_process_report):
-        """Test webhook handling for report.created events"""
+        """Test webhook handling for report.created events."""
         mock_process_report.delay.return_value = MagicMock(id="task_123")
-
         payload = {"id": "report_123", "account": {"id": "account_123"}, "target_account": {"id": "target_account_123"}}
-
-        # Calculate proper HMAC signature
-        import hashlib
-        import hmac
-
         webhook_secret = os.environ["WEBHOOK_SECRET"]
         body = str(payload).encode("utf-8")
         signature = "sha256=" + hmac.new(webhook_secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
-
         response = self.client.post(
             "/webhooks/mastodon_events",
             json=payload,
             headers={"X-Hub-Signature-256": signature, "X-Mastodon-Event": "report.created"},
         )
-
-        # Should process the webhook
         self.assertEqual(response.status_code, 200)
 
     @patch("app.main.process_new_status")
     def test_webhook_status_created(self, mock_process_status):
-        """Test webhook handling for status.created events"""
+        """Test webhook handling for status.created events."""
         mock_process_status.delay.return_value = MagicMock(id="task_456")
-
         payload = {"id": "status_123", "account": {"id": "account_123"}, "content": "test status content"}
-
-        # Calculate proper HMAC signature
-        import hashlib
-        import hmac
-        import json
-
         webhook_secret = os.environ["WEBHOOK_SECRET"]
         body = json.dumps(payload).encode("utf-8")
         signature = "sha256=" + hmac.new(webhook_secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
-
         response = self.client.post(
             "/webhooks/mastodon_events",
             json=payload,
             headers={"X-Hub-Signature-256": signature, "X-Mastodon-Event": "status.created"},
         )
-
-        # Should process the webhook
         self.assertEqual(response.status_code, 200)
 
     def test_unauthorized_analytics(self):
-        """Test that analytics endpoints require authentication"""
+        """Test that analytics endpoints require authentication."""
         response = self.client.get("/api/v1/analytics/overview")
         self.assertEqual(response.status_code, 401)
-
         response = self.client.get("/api/v1/analytics/timeline")
         self.assertEqual(response.status_code, 401)
 
     def test_unauthorized_rules_endpoints(self):
-        """Test that rules endpoints require authentication"""
+        """Test that rules endpoints require authentication."""
         response = self.client.get("/api/v1/rules/")
         self.assertEqual(response.status_code, 401)
-
         response = self.client.post("/api/v1/rules/", json={"name": "test"})
         self.assertEqual(response.status_code, 401)
 
     def test_unauthorized_config_endpoints(self):
-        """Test that config endpoints require authentication"""
-        response = self.client.post("/api/v1/config/dry_run", json={"dry_run": False})
+        """Test that config endpoints require authentication."""
+        response = self.client.post("/api/v1/config/dry_run?enable=false")
         self.assertEqual(response.status_code, 401)
-
-        response = self.client.post("/api/v1/config/panic_stop", json={"panic_stop": True})
+        response = self.client.post("/api/v1/config/panic_stop?enable=true")
         self.assertEqual(response.status_code, 401)
 
     def test_unauthorized_webhook(self):
-        """Test that webhook rejects requests without proper signature"""
+        """Test that webhook rejects requests without proper signature."""
         response = self.client.post(
             "/webhooks/mastodon_events",
             json={"account": {"id": "123"}, "statuses": []},
             headers={"X-Hub-Signature-256": "invalid"},
         )
-        # Should return 401 for invalid signature
         self.assertEqual(response.status_code, 401)
 
 


### PR DESCRIPTION
## Summary
- centralize configuration updates in ConfigService
- expose config APIs through service and sanitize GET response
- document config endpoints

## Testing
- `make format`
- `make lint` *(fails: E712 comparison to False, F841 unused variables, etc.)*
- `make typecheck` *(fails: Source file found twice under different module names: "config" and "app.config")*
- `pytest` *(fails: OperationalError: no such table: config, IntegrityError: NOT NULL constraint failed: rules.id, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6891add95e28832287b2d97db559984d