### PR TITLE
chore: fix mastodon client update script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,16 +75,16 @@ check-httpx-usage:
 
 # OpenAPI client management (using Git submodule)
 update-api-spec:
-	./scripts/update_mastodon_client.sh update-schema
+    ./scripts/mastodon_api.sh update-schema
 
 regenerate-client:
-	./scripts/update_mastodon_client.sh regenerate
+    ./scripts/mastodon_api.sh regenerate
 
 update-mastodon-client:
-	./scripts/update_mastodon_client.sh update
+    ./scripts/mastodon_api.sh update
 
 api-client-status:
-	./scripts/update_mastodon_client.sh status
+    ./scripts/mastodon_api.sh status
 
 # Stop all services
 stop:

--- a/app/clients/mastodon/__init__.py
+++ b/app/clients/mastodon/__init__.py
@@ -1,4 +1,4 @@
-"""A client library for accessing Mastodon API"""
+"""Contains methods for accessing the API"""
 
 from .client import AuthenticatedClient, Client
 

--- a/docs/mastodon-api-client.md
+++ b/docs/mastodon-api-client.md
@@ -22,7 +22,7 @@ Mastowatch/
 │   ├── clients/mastodon/          # Generated Python client
 │   └── mastodon_client.py         # Type-safe client with admin fallbacks
 └── scripts/
-    └── update_mastodon_client.sh  # Management script
+    └── mastodon_api.sh            # Management script
 ```
 
 ## Mastodon Client
@@ -81,16 +81,16 @@ accounts = response.json()
 ### Script Commands
 ```bash
 # Show current status
-./scripts/update_mastodon_client.sh status
+./scripts/mastodon_api.sh status
 
 # Update submodule and copy latest schema
-./scripts/update_mastodon_client.sh update-schema
+./scripts/mastodon_api.sh update-schema
 
 # Regenerate Python client from current schema
-./scripts/update_mastodon_client.sh regenerate
+./scripts/mastodon_api.sh regenerate
 
 # Full update: submodule + schema + client
-./scripts/update_mastodon_client.sh update
+./scripts/mastodon_api.sh update
 ```
 
 ### Makefile Targets

--- a/scripts/mastodon_api.sh
+++ b/scripts/mastodon_api.sh
@@ -92,7 +92,7 @@ init_submodule() {
     fi
 
     # Initialize and update submodule
-    git submodule update --init --recursive "$SUBMODULE_PATH"
+    git submodule update --init "$SUBMODULE_PATH"
     log_success "Submodule initialized"
 }
 

--- a/scripts/mastodon_api.sh
+++ b/scripts/mastodon_api.sh
@@ -85,13 +85,14 @@ init_submodule() {
 
     cd "$PROJECT_ROOT"
 
-    if [ ! -f "$SUBMODULE_PATH/.git" ]; then
-        log_warning "Submodule not initialized. Adding mastodon-openapi submodule..."
+    # Add submodule only if it's not already tracked in .gitmodules
+    if ! git config --file .gitmodules --get-regexp path 2>/dev/null | grep -q "specs/mastodon-openapi"; then
+        log_warning "Submodule not found in .gitmodules. Adding mastodon-openapi submodule..."
         git submodule add https://github.com/abraham/mastodon-openapi.git specs/mastodon-openapi
     fi
 
     # Initialize and update submodule
-    git submodule update --init --recursive
+    git submodule update --init --recursive "$SUBMODULE_PATH"
     log_success "Submodule initialized"
 }
 
@@ -124,12 +125,6 @@ copy_schema() {
         log_error "Schema not found at: $SCHEMA_SOURCE"
         log_info "Try building the submodule first: cd $SUBMODULE_PATH && npm install && npm run generate"
         exit 1
-    fi
-
-    # Create backup of existing schema
-    if [ -f "$SCHEMA_DEST" ]; then
-        cp "$SCHEMA_DEST" "${SCHEMA_DEST}.backup"
-        log_info "Backed up existing schema to: ${SCHEMA_DEST}.backup"
     fi
 
     # Copy new schema
@@ -247,6 +242,17 @@ EOF
 
     # Copy package contents into CLIENT_DIR
     rsync -a --delete "$pkg_dir"/ "$CLIENT_DIR"/
+
+    cat > "$CLIENT_DIR/__init__.py" <<'EOF'
+"""Contains methods for accessing the API"""
+
+from .client import AuthenticatedClient, Client
+
+__all__ = (
+    "AuthenticatedClient",
+    "Client",
+)
+EOF
 
     # Include typing marker if present
     if [ -f "$project_root/py.typed" ]; then


### PR DESCRIPTION
## Summary
- fix mastodon API update script to handle existing submodule and fully regenerate client
- document and makefile updated to use `mastodon_api.sh`
- ensure generated client re-exports `AuthenticatedClient` and `Client`

## Testing
- `./scripts/mastodon_api.sh update`
- `./scripts/mastodon_api.sh regenerate`
- `ruff check app/clients/mastodon/__init__.py`
- `pytest` *(fails: AttributeError, IntegrityError, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6891d41d97108322bed2d9f5a2b63667