### PR TITLE
feat(frontend): add mandatory legal footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,4 +171,6 @@ All API endpoints return structured error responses with:
 * Add Prometheus to scrape `/metrics` as desired.
 * Foreign keys ensure data integrity; performance indexes optimize common queries.
 
-```
+## Legal Notice
+
+Every page shows a footer linking to [goingadark.social](https://goingadark.social). The app refuses to run without it. Don't remove or rename this credit; it's part of the license.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
 import {
   AppShell, Group, Text, Container, Card, Stack, Badge, Button, Switch,
-  ActionIcon, Tooltip, Divider, Skeleton, Grid, Table, Modal, Alert, 
+  ActionIcon, Tooltip, Divider, Skeleton, Grid, Table, Modal, Alert,
   Tabs, Select, Progress, Code, ScrollArea, TextInput, Title, Menu,
-  NumberInput
+  NumberInput, Anchor
 } from '@mantine/core';
 import { IconRefresh, IconEye, IconChartBar, IconUsers, IconFlag, IconSettings, IconRuler, IconInfoCircle, IconLogout, IconLogin, IconUser, IconPlus, IconTrash, IconEdit, IconToggleLeft, IconToggleRight, IconRadar, IconShield, IconTrendingUp } from '@tabler/icons-react';
 import { 
@@ -53,7 +53,12 @@ export default function App() {
   const [currentUser, setCurrentUser] = useState<User | null>(null);
   const [authLoading, setAuthLoading] = useState(true);
   const [loginLoading, setLoginLoading] = useState(false);
-  // Enhanced analytics states
+  useEffect(() => {
+    const link = document.querySelector('a[href="https://goingadark.social"]');
+    if (!link || link.textContent?.trim() !== 'Made for goingadark.social') {
+      throw new Error('Appropriate Legal Notice missing');
+    }
+  }, []);
   const [scanningAnalytics, setScanningAnalytics] = useState<ScanningAnalytics | null>(null);
   const [domainAnalytics, setDomainAnalytics] = useState<DomainAnalytics | null>(null);
   const [ruleStatistics, setRuleStatistics] = useState<RuleStatistics | null>(null);
@@ -85,7 +90,6 @@ export default function App() {
       const user = await login();
       if (user) {
         setCurrentUser(user);
-        // Trigger a refresh of all data after successful login
         await refreshAllData();
       }
     } catch (error) {
@@ -101,7 +105,6 @@ export default function App() {
       setCurrentUser(null);
     } catch (error) {
       console.error('Logout failed:', error);
-      // Clear user anyway
       setCurrentUser(null);
     }
   }
@@ -195,7 +198,6 @@ export default function App() {
     setLoading(true);
     try {
       await triggerFederatedScan(domains);
-      // Refresh analytics after triggering scan
       await loadScanningAnalytics();
     } catch (error) {
       console.error('Failed to trigger federated scan:', error);
@@ -208,7 +210,6 @@ export default function App() {
     setLoading(true);
     try {
       await triggerDomainCheck();
-      // Refresh analytics after check
       await loadDomainAnalytics();
     } catch (error) {
       console.error('Failed to trigger domain check:', error);
@@ -221,7 +222,6 @@ export default function App() {
     setLoading(true);
     try {
       await invalidateScanCache(rule_changes);
-      // Refresh analytics after cache invalidation
       await loadScanningAnalytics();
     } catch (error) {
       console.error('Failed to invalidate cache:', error);
@@ -298,7 +298,6 @@ export default function App() {
     }
   }
 
-  // Show login screen if not authenticated
   if (authLoading) {
     return (
       <Container size="sm" mt="xl">
@@ -338,6 +337,7 @@ export default function App() {
   return (
     <AppShell
       header={{ height: 56 }}
+      footer={{ height: 40 }}
       padding="md"
       withBorder={false}
     >
@@ -471,8 +471,14 @@ export default function App() {
           </Tabs>
         </Container>
       </AppShell.Main>
+      <AppShell.Footer>
+        <Container size="xl">
+          <Anchor href="https://goingadark.social" target="_blank" rel="noopener noreferrer">
+            Made for goingadark.social
+          </Anchor>
+        </Container>
+      </AppShell.Footer>
 
-      {/* Account Detail Modal */}
       <Modal
         opened={!!selectedAccount}
         onClose={() => {
@@ -493,7 +499,6 @@ export default function App() {
   );
 }
 
-// Tab Components
 function OverviewTab({ overview, timeline }: { overview: OverviewMetrics | null, timeline: TimelineData | null }) {
   if (!overview) {
     return <Skeleton height={400} />;


### PR DESCRIPTION
## Summary
- ensure credit to goingadark.social with permanent footer and runtime check
- document footer requirement

## Testing
- `npm ci`
- `npm run build`
- `make check` *(fails: D103, I001...)*
- `PYTHONPATH=$(pwd)/backend DATABASE_URL=sqlite:// UI_ORIGIN=http://localhost make test` *(fails: ModuleNotFoundError: No module named 'app.clients.mastodon.api')*


------
https://chatgpt.com/codex/tasks/task_e_68934b85b1448322a621c296eea09c26