### PR TITLE
feat: add enforcement audit logs and admin endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Analyze accounts/statuses and **file reports via API** so human moderators act i
 - ✅ **Frontend**: Enhanced settings interface with error states and real-time configuration
 - ✅ **Testing**: Comprehensive edge case test coverage (22 test scenarios)
 - ✅ **CI/CD**: Automated testing, static analysis, and code formatting
+- ✅ **Audit Logs**: Enforcement actions recorded with rule context and API responses
+- ✅ **User Notifications**: Warnings and suspensions include messages sent through Mastodon
 
 ## Quick start
 
@@ -143,6 +145,7 @@ Endpoints:
 #### Analytics & Data (requires admin login)
 * `GET /analytics/overview` - System analytics overview with account/report metrics
 * `GET /analytics/timeline?days=N` - Timeline analytics for the past N days (1-365)
+* `GET /logs` - Enforcement audit log entries
 
 #### Authentication
 * `GET /admin/login` - Initiate OAuth login flow for admin access

--- a/backend/app/api/logs.py
+++ b/backend/app/api/logs.py
@@ -1,0 +1,38 @@
+"""Audit log inspection endpoints."""
+
+from app.db import SessionLocal
+from app.models import AuditLog
+from app.oauth import User, require_admin_hybrid
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+router = APIRouter()
+
+
+@router.get("/logs", tags=["logs"])
+def list_logs(
+    account_id: str | None = Query(None),
+    rule_id: int | None = Query(None),
+    limit: int = Query(100, ge=1, le=1000),
+    user: User = Depends(require_admin_hybrid),
+    session: Session = Depends(SessionLocal),
+):
+    """List audit log entries."""
+    query = session.query(AuditLog).order_by(AuditLog.timestamp.desc())
+    if account_id:
+        query = query.filter(AuditLog.target_account_id == account_id)
+    if rule_id:
+        query = query.filter(AuditLog.triggered_by_rule_id == rule_id)
+    logs = query.limit(limit).all()
+    return [
+        {
+            "id": log.id,
+            "action_type": log.action_type,
+            "triggered_by_rule_id": log.triggered_by_rule_id,
+            "target_account_id": log.target_account_id,
+            "timestamp": log.timestamp.isoformat() if log.timestamp else None,
+            "evidence": log.evidence,
+            "api_response": log.api_response,
+        }
+        for log in logs
+    ]

--- a/backend/app/api/logs.py
+++ b/backend/app/api/logs.py
@@ -15,7 +15,7 @@ def list_logs(
     rule_id: int | None = Query(None),
     limit: int = Query(100, ge=1, le=1000),
     user: User = Depends(require_admin_hybrid),
-    session: Session = Depends(SessionLocal),
+    session: Session = Depends(get_db),
 ):
     """List audit log entries."""
     query = session.query(AuditLog).order_by(AuditLog.timestamp.desc())

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,6 +10,7 @@ import redis
 from app.api.analytics import router as analytics_router
 from app.api.auth import router as auth_router
 from app.api.config import router as config_router
+from app.api.logs import router as logs_router
 from app.api.rules import router as rules_router
 from app.api.scanning import router as scanning_router
 from app.config import get_settings
@@ -44,6 +45,7 @@ app.include_router(rules_router)
 app.include_router(config_router)
 app.include_router(scanning_router)
 app.include_router(auth_router)
+app.include_router(logs_router)
 
 if settings.CORS_ORIGINS:
     app.add_middleware(

--- a/backend/app/services/enforcement_service.py
+++ b/backend/app/services/enforcement_service.py
@@ -59,12 +59,17 @@ class EnforcementService:
             return
         path = f"/api/v1/admin/accounts/{account_id}/action"
         resp = self.mastodon_client._make_request("POST", path, json=payload)
+        try:
+            api_response = resp.json()
+        except Exception as e:
+            logger.error("Failed to decode JSON response for account %s: %s", account_id, str(e))
+            api_response = {"error": "Invalid JSON response", "response_text": getattr(resp, "text", None)}
         self._log_action(
             action_type=payload.get("type", ""),
             account_id=account_id,
             rule_id=rule_id,
             evidence=evidence,
-            api_response=resp.json(),
+            api_response=api_response,
         )
 
     def warn_account(
@@ -138,12 +143,17 @@ class EnforcementService:
             return
         path = f"/api/v1/admin/accounts/{account_id}/unsilence"
         resp = self.mastodon_client._make_request("POST", path)
+        try:
+            api_response = resp.json()
+        except (ValueError, json.decoder.JSONDecodeError) as e:
+            logger.error("Failed to decode JSON response for unsilence_account: %s", e)
+            api_response = {"error": "Invalid JSON response", "response_text": resp.text}
         self._log_action(
             action_type="unsilence",
             account_id=account_id,
             rule_id=rule_id,
             evidence=evidence,
-            api_response=resp.json(),
+            api_response=api_response,
         )
 
     def unsuspend_account(
@@ -166,10 +176,15 @@ class EnforcementService:
             return
         path = f"/api/v1/admin/accounts/{account_id}/unsuspend"
         resp = self.mastodon_client._make_request("POST", path)
+        try:
+            api_response = resp.json()
+        except ValueError as e:
+            logger.error("Failed to decode JSON response for unsuspend_account: %s", e)
+            api_response = {"error": "Invalid JSON response"}
         self._log_action(
             action_type="unsuspend",
             account_id=account_id,
             rule_id=rule_id,
             evidence=evidence,
-            api_response=resp.json(),
+            api_response=api_response,
         )

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -22,6 +22,7 @@ MastoWatch now includes comprehensive production-readiness features:
 - **Health endpoints** returning proper HTTP status codes (503 for service failures)
 - **Prometheus metrics** with detailed application metrics
 - **Analytics dashboard** with real-time system status
+- **Audit logs** for enforcement actions accessible via `/logs`
 
 ## Quick Start
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ Test utilities for MastoWatch testing
 """
 
 from unittest.mock import patch
+
 from app.oauth import User
 
 
@@ -10,11 +11,11 @@ def create_mock_admin_user():
     """Create a mock admin user for testing"""
     return User(
         id="test_user_123",
-        username="testadmin", 
+        username="testadmin",
         acct="testadmin@test.example",
         display_name="Test Admin",
         is_admin=True,
-        avatar=None
+        avatar=None,
     )
 
 
@@ -23,17 +24,17 @@ def create_mock_regular_user():
     return User(
         id="test_user_456",
         username="testuser",
-        acct="testuser@test.example", 
+        acct="testuser@test.example",
         display_name="Test User",
         is_admin=False,
-        avatar=None
+        avatar=None,
     )
 
 
 def mock_require_admin(admin_user=None):
     """
     Context manager to mock require_admin dependency
-    Usage: 
+    Usage:
         with mock_require_admin():
             # admin_user is mocked as authenticated admin
     """


### PR DESCRIPTION
## Summary
- log enforcement actions with rule references and API responses
- expose read-only audit log endpoint for admins
- document new moderation logs and user notifications

## Testing
- `make lint` *(fails: D103 missing docstring in tests/test_startup_validation.py and import sorting errors)*
- `make typecheck` *(fails: Duplicate module named "auth")*
- `make test` *(fails: ModuleNotFoundError: No module named 'app.clients.mastodon.api')*


------
https://chatgpt.com/codex/tasks/task_e_68934e96b5c88322999f87bc501b98e5