### PR TITLE
fix(ci): use correct requirements paths

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -22,45 +22,17 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt', 'requirements-test.txt') }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('backend/requirements.txt', 'tests/requirements-test.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
-          
+
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt -r requirements-test.txt
-        
-    - name: Lint with flake8
-      run: |
-        # Stop build if there are Python syntax errors or undefined names
-        flake8 app tests --count --select=E9,F63,F7,F82 --show-source --statistics
-        # Check for critical issues only (ignore style and complexity for now)
-        flake8 app tests --count --select=E9,F63,F7,F82,F401,E722 --statistics --exit-zero
-        
-    - name: Format check with black (informational)
-      run: |
-        black --check --diff app tests || true
-        
-    - name: Type check with mypy (main modules only)
-      run: |
-        mypy app/main.py app/config.py app/oauth.py --ignore-missing-imports
-        
-    - name: Security check with bandit
-      run: |
-        pip install bandit[toml]
-        bandit -r app -f json -o bandit-report.json || true
-        bandit -r app --severity medium --exit-zero
-        
-    - name: Check httpx usage
-      run: |
-        ./scripts/check-httpx-usage.sh
-        
-    - name: Run Python tests
-      env:
-        SKIP_STARTUP_VALIDATION: "1"
-      run: |
-        pytest
+        pip install -r backend/requirements.txt -r tests/requirements-test.txt
+
+    - name: Run checks
+      run: make check
 
   frontend-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- fix requirements paths in CI workflow
- run checks via `make check`

## Testing
- `DATABASE_URL=sqlite:// UI_ORIGIN=http://localhost PYTHONPATH=backend make check` *(fails: Found 217 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68935fd81af88322a47a3d4c1e0a97bf