### PR TITLE
feat: add media detector for attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Analyze accounts/statuses and **file reports via API** so human moderators act i
 - ✅ **CI/CD**: Automated testing, static analysis, and code formatting
 - ✅ **Audit Logs**: Enforcement actions recorded with rule context and API responses
 - ✅ **User Notifications**: Warnings and suspensions include messages sent through Mastodon
+- ✅ **Media-aware Scanning**: Analyzes attachments for alt text, MIME types, and URL hashes
 
 ## Quick start
 

--- a/backend/app/services/detectors/media_detector.py
+++ b/backend/app/services/detectors/media_detector.py
@@ -1,0 +1,47 @@
+"""Detector for media attachments."""
+
+from hashlib import sha256
+from typing import Any
+
+from app.models import Rule
+from app.schemas import Evidence, Violation
+from app.services.detectors.base import BaseDetector
+
+
+class MediaDetector(BaseDetector):
+    """Evaluate alt text, MIME types, and URL hashes of attachments."""
+
+    def evaluate(self, rule: Rule, account_data: dict[str, Any], statuses: list[dict[str, Any]]) -> list[Violation]:
+        """Find violations in media attachments."""
+        violations: list[Violation] = []
+        pattern = rule.pattern.lower()
+        for status in statuses or []:
+            for attachment in status.get("media_attachments", []):
+                alt_text = (attachment.get("description") or "").lower()
+                mime = (attachment.get("mime_type") or "").lower()
+                url = attachment.get("url") or attachment.get("remote_url") or ""
+                hash_value = sha256(url.encode()).hexdigest() if url else ""
+                matched_terms: list[str] = []
+                metrics: dict[str, Any] = {}
+                if pattern in alt_text:
+                    matched_terms.append(alt_text)
+                    metrics["alt_text"] = alt_text
+                if pattern in mime:
+                    matched_terms.append(mime)
+                    metrics["mime_type"] = mime
+                if pattern == hash_value:
+                    matched_terms.append(hash_value)
+                    metrics["hash"] = hash_value
+                if matched_terms:
+                    violations.append(
+                        Violation(
+                            rule_name=rule.name,
+                            score=rule.weight,
+                            evidence=Evidence(
+                                matched_terms=matched_terms,
+                                matched_status_ids=[status.get("id")],
+                                metrics=metrics,
+                            ),
+                        )
+                    )
+        return violations

--- a/backend/app/services/rule_service.py
+++ b/backend/app/services/rule_service.py
@@ -1,10 +1,10 @@
+"""Rule management service."""
+
 import hashlib
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any
-
-from sqlalchemy import text
 
 from app.config import get_settings
 from app.db import SessionLocal
@@ -12,7 +12,9 @@ from app.models import Rule
 from app.schemas import Evidence, Violation
 from app.services.detectors.behavioral_detector import BehavioralDetector
 from app.services.detectors.keyword_detector import KeywordDetector
+from app.services.detectors.media_detector import MediaDetector
 from app.services.detectors.regex_detector import RegexDetector
+from sqlalchemy import text
 
 settings = get_settings()
 logger = logging.getLogger(__name__)
@@ -50,6 +52,7 @@ class RuleService:
             "regex": RegexDetector(),
             "keyword": KeywordDetector(),
             "behavioral": BehavioralDetector(),
+            "media": MediaDetector(),
         }
 
     def get_active_rules(self, force_refresh: bool = False) -> tuple[list[Rule], dict[str, Any], str]:
@@ -71,7 +74,7 @@ class RuleService:
         """Load rules from database and update cache"""
         with SessionLocal() as session:
             # Get all enabled rules
-            db_rules = session.query(Rule).filter(Rule.enabled == True).all()
+            db_rules = session.query(Rule).filter(Rule.enabled.is_(True)).all()
 
             # Create a hash from all the rule data for versioning
             rule_data = []

--- a/tests/test_enhanced_scanning.py
+++ b/tests/test_enhanced_scanning.py
@@ -38,7 +38,7 @@ class TestEnhancedScanningSystem(unittest.TestCase):
     """Test enhanced scanning system functionality"""
 
     def setUp(self):
-        # Mock database
+        """Prepare database and client mocks."""
         self.db_patcher = patch("app.scanning.SessionLocal")
         self.mock_db = self.db_patcher.start()
         self.mock_session = MagicMock()
@@ -53,6 +53,7 @@ class TestEnhancedScanningSystem(unittest.TestCase):
         self.mock_masto_client = self.client_patcher.start()
         self.mock_client_instance = MagicMock()
         self.mock_masto_client.return_value = self.mock_client_instance
+        self.mock_client_instance.get_account_statuses.return_value = []
 
         self.rule_service_patcher = patch("app.scanning.rule_service")
         self.mock_rule_service = self.rule_service_patcher.start()
@@ -64,6 +65,7 @@ class TestEnhancedScanningSystem(unittest.TestCase):
         self.scanning_system = EnhancedScanningSystem()
 
     def tearDown(self):
+        """Stop patches."""
         self.db_patcher.stop()
         self.client_patcher.stop()
         self.rule_service_patcher.stop()
@@ -128,9 +130,8 @@ class TestEnhancedScanningSystem(unittest.TestCase):
         self.mock_session.add.return_value = None
         self.mock_session.refresh.return_value = None
 
-        session_id = self.scanning_system.start_scan_session("test_type", {"key": "value"})
+        self.scanning_system.start_scan_session("test_type", {"key": "value"})
 
-        # Verify session was created
         self.mock_session.add.assert_called_once()
         self.mock_session.commit.assert_called_once()
 
@@ -381,7 +382,10 @@ class TestEnhancedScanningSystem(unittest.TestCase):
     def test_get_active_domains(self):
         """Test getting list of active domains for scanning"""
         # Mock domain query results
-        self.mock_session.query.return_value.filter.return_value.distinct.return_value.limit.return_value.all.return_value = [
+        query_chain = (
+            self.mock_session.query.return_value.filter.return_value.distinct.return_value.limit.return_value.all
+        )
+        query_chain.return_value = [
             ("example.com",),
             ("test.org",),
             ("sample.net",),
@@ -438,13 +442,21 @@ class TestEnhancedScanningSystem(unittest.TestCase):
                 )
             ]
 
-            mock_response = MagicMock()
-            mock_response.json.return_value = [{"content": "spam content"}]
-            self.mock_client_instance.get.return_value = mock_response
+            def statuses_side_effect(account_id, limit, only_media=False):
+                return [{"id": "1", "content": "spam content", "media_attachments": []}]
+
+            self.mock_client_instance.get_account_statuses.side_effect = statuses_side_effect
 
             with patch.object(self.scanning_system, "_track_domain_violation") as mock_track:
-                result = self.scanning_system.scan_account_efficiently(account_data, 1)
-
+                self.scanning_system.scan_account_efficiently(account_data, 1)
+                self.mock_client_instance.get_account_statuses.assert_any_call(
+                    account_id="test_account_123", limit=self.scanning_system.settings.MAX_STATUSES_TO_FETCH
+                )
+                self.mock_client_instance.get_account_statuses.assert_any_call(
+                    account_id="test_account_123",
+                    limit=self.scanning_system.settings.MAX_STATUSES_TO_FETCH,
+                    only_media=True,
+                )
                 mock_track.assert_called_once_with("bad.example")
 
 


### PR DESCRIPTION
## Summary
- scan media attachments for alt text, MIME types, and URL hashes
- expose `media` detector type to rule API
- pull media-only statuses during account scanning

## Testing
- `make check` *(fails: ruff reports many existing style violations in rules API)*
- `pytest` *(fails: missing `app` module due to unresolved dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689360172cbc8322a1d77c051f89519d