### PR TITLE
fix: correct domain typo

### DIFF
--- a/LICENSE-ADDITIONS
+++ b/LICENSE-ADDITIONS
@@ -4,7 +4,7 @@ If the Program or any modified version provides an interactive user interface,
 you must preserve an “Appropriate Legal Notice” that is readily visible to users.
 That notice must include:
 
-  “Made for goingadark.social”  (hyperlinked to https://goingadark.social)
+  “Made for goingdark.social”  (hyperlinked to https://goingdark.social)
 
 Visibility & placement: The notice must appear on every user-visible page or
 screen where the Program renders UI (e.g., a persistent footer or a fixed

--- a/README.md
+++ b/README.md
@@ -177,4 +177,4 @@ All API endpoints return structured error responses with:
 
 ## Legal Notice
 
-Every page shows a footer linking to [goingadark.social](https://goingadark.social). The app refuses to run without it. Don't remove or rename this credit; it's part of the license.
+Every page shows a footer linking to [goingdark.social](https://goingdark.social). The app refuses to run without it. Don't remove or rename this credit; it's part of the license.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -54,8 +54,8 @@ export default function App() {
   const [authLoading, setAuthLoading] = useState(true);
   const [loginLoading, setLoginLoading] = useState(false);
   useEffect(() => {
-    const link = document.querySelector('a[href="https://goingadark.social"]');
-    if (!link || link.textContent?.trim() !== 'Made for goingadark.social') {
+    const link = document.querySelector('a[href="https://goingdark.social"]');
+    if (!link || link.textContent?.trim() !== 'Made for goingdark.social') {
       throw new Error('Appropriate Legal Notice missing');
     }
   }, []);
@@ -473,8 +473,8 @@ export default function App() {
       </AppShell.Main>
       <AppShell.Footer>
         <Container size="xl">
-          <Anchor href="https://goingadark.social" target="_blank" rel="noopener noreferrer">
-            Made for goingadark.social
+          <Anchor href="https://goingdark.social" target="_blank" rel="noopener noreferrer">
+            Made for goingdark.social
           </Anchor>
         </Container>
       </AppShell.Footer>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,6 +35,9 @@ type Health = {
 
 const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff7300', '#8dd1e1', '#d084d0'];
 
+const LEGAL_NOTICE_URL = 'https://goingdark.social';
+const LEGAL_NOTICE_TEXT = 'Made for goingdark.social';
+
 export default function App() {
   const [activeTab, setActiveTab] = useState('overview');
   const [health, setHealth] = useState<Health | null>(null);
@@ -54,8 +57,8 @@ export default function App() {
   const [authLoading, setAuthLoading] = useState(true);
   const [loginLoading, setLoginLoading] = useState(false);
   useEffect(() => {
-    const link = document.querySelector('a[href="https://goingdark.social"]');
-    if (!link || link.textContent?.trim() !== 'Made for goingdark.social') {
+    const link = document.querySelector(`a[href="${LEGAL_NOTICE_URL}"]`);
+    if (!link || link.textContent?.trim() !== LEGAL_NOTICE_TEXT) {
       throw new Error('Appropriate Legal Notice missing');
     }
   }, []);
@@ -473,8 +476,8 @@ export default function App() {
       </AppShell.Main>
       <AppShell.Footer>
         <Container size="xl">
-          <Anchor href="https://goingdark.social" target="_blank" rel="noopener noreferrer">
-            Made for goingdark.social
+          <Anchor href={LEGAL_NOTICE_URL} target="_blank" rel="noopener noreferrer">
+            {LEGAL_NOTICE_TEXT}
           </Anchor>
         </Container>
       </AppShell.Footer>


### PR DESCRIPTION
## Summary
- correct domain link and text to goingdark.social

## Testing
- `npm ci`
- `npm run build`
- `make check` *(fails: missing docstrings, 176 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68936530ac988322b22fc2afb3170e5b