### PR TITLE
fix(ci): install linting dependencies

### DIFF
--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -126,18 +126,14 @@ WEBHOOK_SECRET=test_webhook_secret_123  # For webhook signature tests
 ```
 
 ### Static Analysis & Code Quality
+Use the Makefile targets to keep the codebase clean and consistent:
+
 ```bash
-# Auto-format code
-black app tests
-
-# Organize imports  
-isort app tests
-
-# Check critical linting issues
-flake8 app tests --select=E9,F63,F7,F82
-
-# Security scanning
-bandit -r app
+make format       # Format code with Black
+make lint         # Lint with Ruff
+make typecheck    # Run MyPy
+make test         # Run tests
+make check        # Run all of the above
 ```
 
 ### Pull Request Image Builds

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -9,3 +9,6 @@ requests>=2.31.0
 factory-boy>=3.3.0
 faker>=20.0.0
 freezegun>=1.2.0
+black>=24.1.1
+mypy>=1.10.0
+ruff>=0.5.0


### PR DESCRIPTION
## Summary
- install black, mypy, and ruff for CI linting
- document project lint commands

## Testing
- `make check` *(fails: D103 Missing docstring in public function)*

------
https://chatgpt.com/codex/tasks/task_e_6893640814c88322ab6086e15f9dcff5