### PR TITLE
feat(config): add automod configuration endpoint

### DIFF
--- a/backend/app/api/config.py
+++ b/backend/app/api/config.py
@@ -2,12 +2,12 @@
 
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, status
-
 from app.auth import require_api_key
 from app.config import get_settings
 from app.oauth import User, require_admin_hybrid
 from app.services.config_service import ConfigService, get_config_service
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
 
 router = APIRouter()
 
@@ -15,6 +15,14 @@ api_key_dep = Depends(require_api_key)
 admin_dep = Depends(require_admin_hybrid)
 service_dep = Depends(get_config_service)
 MAX_THRESHOLD = 10
+
+
+class AutoModSettings(BaseModel):
+    """AutoMod configuration options."""
+
+    dry_run_override: bool | None = Field(default=None)
+    default_action: str | None = Field(default=None)
+    defederation_threshold: int | None = Field(default=None)
 
 
 @router.get("/config", response_model=dict[str, Any])
@@ -76,6 +84,42 @@ def set_report_threshold(
 ):
     """Update report threshold."""
     if threshold < 0 or threshold > MAX_THRESHOLD:
-        raise HTTPException(status_code=400, detail="Threshold must be between 0 and 10")
+        raise HTTPException(
+            status_code=400, detail="Threshold must be between 0 and 10"
+        )
     service.set_threshold("report_threshold", threshold, updated_by=user.username)
     return {"report_threshold": threshold}
+
+
+@router.get("/config/automod", tags=["ops"], response_model=dict[str, Any])
+def get_automod_config(
+    user: User = admin_dep,
+    service: ConfigService = service_dep,
+):
+    """Return current AutoMod settings."""
+    config = service.get_config("automod") or {}
+    return {
+        "dry_run_override": config.get("dry_run_override"),
+        "default_action": config.get("default_action"),
+        "defederation_threshold": config.get("defederation_threshold"),
+    }
+
+
+@router.post("/config/automod", tags=["ops"], response_model=dict[str, Any])
+def set_automod_config(
+    settings: AutoModSettings,
+    user: User = admin_dep,
+    service: ConfigService = service_dep,
+):
+    """Update AutoMod settings."""
+    if (
+        settings.defederation_threshold is not None
+        and settings.defederation_threshold < 0
+    ):
+        raise HTTPException(status_code=400, detail="Threshold must be non-negative")
+    return service.set_automod_config(
+        dry_run_override=settings.dry_run_override,
+        default_action=settings.default_action,
+        defederation_threshold=settings.defederation_threshold,
+        updated_by=user.username,
+    )

--- a/backend/app/services/config_service.py
+++ b/backend/app/services/config_service.py
@@ -15,7 +15,9 @@ class ConfigService:
             row = session.get(Config, key)
             return row.value if row else None
 
-    def set_flag(self, key: str, enabled: bool, updated_by: str | None = None) -> dict[str, bool]:
+    def set_flag(
+        self, key: str, enabled: bool, updated_by: str | None = None
+    ) -> dict[str, bool]:
         """Store boolean flag in configuration."""
         with SessionLocal() as session:
             config = session.get(Config, key)
@@ -23,11 +25,15 @@ class ConfigService:
                 config.value = {"enabled": enabled}
                 config.updated_by = updated_by
             else:
-                session.add(Config(key=key, value={"enabled": enabled}, updated_by=updated_by))
+                session.add(
+                    Config(key=key, value={"enabled": enabled}, updated_by=updated_by)
+                )
             session.commit()
             return {"enabled": enabled}
 
-    def set_threshold(self, key: str, threshold: float, updated_by: str | None = None) -> dict[str, float]:
+    def set_threshold(
+        self, key: str, threshold: float, updated_by: str | None = None
+    ) -> dict[str, float]:
         """Store numeric threshold in configuration."""
         with SessionLocal() as session:
             config = session.get(Config, key)
@@ -35,9 +41,39 @@ class ConfigService:
                 config.value = {"threshold": threshold}
                 config.updated_by = updated_by
             else:
-                session.add(Config(key=key, value={"threshold": threshold}, updated_by=updated_by))
+                session.add(
+                    Config(
+                        key=key, value={"threshold": threshold}, updated_by=updated_by
+                    )
+                )
             session.commit()
             return {"threshold": threshold}
+
+    def set_automod_config(
+        self,
+        *,
+        dry_run_override: bool | None = None,
+        default_action: str | None = None,
+        defederation_threshold: int | None = None,
+        updated_by: str | None = None,
+    ) -> dict[str, Any]:
+        """Update AutoMod settings."""
+        with SessionLocal() as session:
+            config = session.get(Config, "automod")
+            value = config.value if config else {}
+            if dry_run_override is not None:
+                value["dry_run_override"] = dry_run_override
+            if default_action is not None:
+                value["default_action"] = default_action
+            if defederation_threshold is not None:
+                value["defederation_threshold"] = defederation_threshold
+            if config:
+                config.value = value
+                config.updated_by = updated_by
+            else:
+                session.add(Config(key="automod", value=value, updated_by=updated_by))
+            session.commit()
+            return value
 
 
 config_service = ConfigService()

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -220,9 +220,10 @@ alembic history        # Show migration history
 The frontend now includes:
 - **Real-time configuration** with immediate feedback
 - **Error handling** with user-friendly alerts
-- **System status monitoring** with service health indicators  
+- **System status monitoring** with service health indicators
 - **Analytics dashboard** with account and report metrics
 - **Persistence validation** ensuring settings are properly saved
+- **AutoMod configuration** at `/config/automod` for DRY_RUN overrides, default actions, and defederation limits
 
 ### Frontend Development Commands
 ```bash

--- a/tests/services/test_config_service.py
+++ b/tests/services/test_config_service.py
@@ -5,11 +5,10 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-
 from app.db import Base
 from app.services.config_service import ConfigService
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
 
 class TestConfigService(unittest.TestCase):
@@ -22,7 +21,9 @@ class TestConfigService(unittest.TestCase):
         Base.metadata.create_all(engine)
         self.SessionLocal = sessionmaker(bind=engine)
         self.service = ConfigService()
-        self.patcher = patch("app.services.config_service.SessionLocal", self.SessionLocal)
+        self.patcher = patch(
+            "app.services.config_service.SessionLocal", self.SessionLocal
+        )
         self.patcher.start()
 
     def tearDown(self):
@@ -41,6 +42,19 @@ class TestConfigService(unittest.TestCase):
         self.service.set_threshold("report_threshold", 2.5, updated_by="tester")
         value = self.service.get_config("report_threshold")
         self.assertEqual(value["threshold"], 2.5)
+
+    def test_set_automod_config(self):
+        """Store and retrieve automod settings."""
+        self.service.set_automod_config(
+            dry_run_override=False,
+            default_action="suspend",
+            defederation_threshold=5,
+            updated_by="tester",
+        )
+        value = self.service.get_config("automod")
+        self.assertEqual(value["dry_run_override"], False)
+        self.assertEqual(value["default_action"], "suspend")
+        self.assertEqual(value["defederation_threshold"], 5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add ConfigService support for AutoMod settings
- expose /config/automod endpoint for retrieving and updating AutoMod options
- document AutoMod configuration via FastAPI admin interface

## Testing
- `make check` *(fails: D100 ... ModuleNotFoundError)*
- `ruff check backend/app/api/config.py backend/app/services/config_service.py tests/services/test_config_service.py tests/test_api.py`
- `pytest tests/services/test_config_service.py tests/test_api.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_689391b8645083228486ad237429935a