### PR TITLE
feat: add UI origin configuration

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -35,7 +35,8 @@ services:
       PANIC_STOP: "false"
       SKIP_STARTUP_VALIDATION: "false"
       CORS_ORIGINS: '["http://localhost:3000", "http://localhost:5173"]'
-      
+      UI_ORIGIN: "${UI_ORIGIN:-http://localhost:5173}"
+
       # Development tokens (replace with actual values from your test instance)
       INSTANCE_BASE: "${INSTANCE_BASE:-https://your-test-instance.example.com}"
       BOT_TOKEN: "${BOT_TOKEN:-REPLACE_WITH_YOUR_DEV_BOT_TOKEN}"
@@ -62,13 +63,14 @@ services:
       # Development safety settings - see docs/ENVIRONMENT.md
       DRY_RUN: "true"
       PANIC_STOP: "false"
-      
+
       # Development tokens (inherit from environment or use defaults)
       INSTANCE_BASE: "${INSTANCE_BASE:-https://your-test-instance.example.com}"
       BOT_TOKEN: "${BOT_TOKEN:-REPLACE_WITH_YOUR_DEV_BOT_TOKEN}"
       ADMIN_TOKEN: "${ADMIN_TOKEN:-REPLACE_WITH_YOUR_DEV_ADMIN_TOKEN}"
       API_KEY: "${API_KEY:-dev_api_key_change_in_production}"
       WEBHOOK_SECRET: "${WEBHOOK_SECRET:-dev_webhook_secret_change_in_production}"
+      UI_ORIGIN: "${UI_ORIGIN:-http://localhost:5173}"
     volumes:
       - ./backend/app:/app/app
       - ./backend/migrations:/app/migrations
@@ -90,6 +92,7 @@ services:
       ADMIN_TOKEN: "${ADMIN_TOKEN:-REPLACE_WITH_YOUR_DEV_ADMIN_TOKEN}"
       API_KEY: "${API_KEY:-dev_api_key_change_in_production}"
       WEBHOOK_SECRET: "${WEBHOOK_SECRET:-dev_webhook_secret_change_in_production}"
+      UI_ORIGIN: "${UI_ORIGIN:-http://localhost:5173}"
     volumes:
       - ./backend/app:/app/app
       - ./backend/migrations:/app/migrations
@@ -98,6 +101,7 @@ services:
     environment:
       # Development database connection
       DATABASE_URL: postgresql+psycopg://mastowatch:mastowatch@db:5432/mastowatch
+      UI_ORIGIN: "${UI_ORIGIN:-http://localhost:5173}"
 
   frontend:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ x-backend-env: &backend-env
   
   # Frontend Integration
   CORS_ORIGINS: '${CORS_ORIGINS:-["https://your-domain.com"]}'
+  UI_ORIGIN: "${UI_ORIGIN}"
   
   # Optional OAuth Configuration
   OAUTH_CLIENT_ID: "${OAUTH_CLIENT_ID:-}"

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -56,6 +56,7 @@ These variables must be set for MastoWatch to function properly:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `CORS_ORIGINS` | `["http://localhost:3000"]` | JSON array of allowed CORS origins |
+| `UI_ORIGIN` | `http://localhost:5173` | Base URL of the dashboard UI |
 
 ### OAuth Configuration (Admin Dashboard)
 


### PR DESCRIPTION
## Summary
- expose `UI_ORIGIN` in backend compose env
- pass through `UI_ORIGIN` in development overrides
- document `UI_ORIGIN`

## Testing
- `make check` *(fails: Found 173 errors)*
- `make test` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6893e63b027483229f84780c1b3e3620