### PR TITLE
chore(deps): add celery sqlalchemy scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ All API endpoints return structured error responses with:
 
 ## Notes
 
-* Celery Beat intervals are configurable via environment variables.
+* Celery Beat uses a database-backed schedule via `celery-sqlalchemy-scheduler`, and intervals are configurable through environment variables.
 * All endpoints use structured JSON logging with request IDs for troubleshooting.
 * Alembic migrations run via the `migrate` service. Note that `alembic.ini` leaves `sqlalchemy.url` empty; the `DATABASE_URL` environment variable is used instead.
 * Add Prometheus to scrape `/metrics` as desired.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,7 @@
 fastapi==0.116.1
 uvicorn[standard]==0.35.0
 celery[redis]==5.5.3
+celery-sqlalchemy-scheduler==0.3.0
 redis>=5,<7
 psycopg[binary]==3.2.9
 SQLAlchemy==2.0.42


### PR DESCRIPTION
## Summary
- add celery-sqlalchemy-scheduler for DB-backed beat schedule
- document database-backed beat scheduler

## Testing
- `pip install -r backend/requirements.txt`
- `make check` *(fails: Found 173 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6893e637b0048322ac951aa801dc1e3f