### PR TITLE
test: recompute webhook signature

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -347,9 +347,9 @@ class TestAPIEndpoints(unittest.TestCase):
             "id": "report_123",
             "account": {"id": "account_123"},
             "target_account": {"id": "target_account_123"},
-        }
+        } 
         webhook_secret = os.environ["WEBHOOK_SECRET"]
-        body = str(payload).encode("utf-8")
+        body = json.dumps(payload).encode("utf-8")
         signature = (
             "sha256="
             + hmac.new(webhook_secret.encode("utf-8"), body, hashlib.sha256).hexdigest()


### PR DESCRIPTION
## Summary
- encode webhook payload as JSON before calculating signature

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'app.clients.mastodon.api')*

------
https://chatgpt.com/codex/tasks/task_e_6894e99bed648322984873f0c36b4cec