### PR TITLE
refactor(tests): centralize test setup

### DIFF
--- a/backend/app/api/logs.py
+++ b/backend/app/api/logs.py
@@ -1,6 +1,6 @@
 """Audit log inspection endpoints."""
 
-from app.db import SessionLocal
+from app.db import get_db
 from app.models import AuditLog
 from app.oauth import User, require_admin_hybrid
 from fastapi import APIRouter, Depends, Query

--- a/tests/tasks/test_tasks.py
+++ b/tests/tasks/test_tasks.py
@@ -1,9 +1,5 @@
-import sys
 import unittest
-from pathlib import Path
 from unittest.mock import MagicMock, patch, call
-
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import app.tasks.jobs as jobs
 from app.schemas import Violation

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,28 +4,9 @@ import hashlib
 import hmac
 import json
 import os
-import sys
 import unittest
 from datetime import datetime
-from pathlib import Path
 from unittest.mock import MagicMock, patch
-
-# Set test environment before any imports
-os.environ.update(
-    {
-        "SKIP_STARTUP_VALIDATION": "1",
-        "INSTANCE_BASE": "https://test.mastodon.social",
-        "ADMIN_TOKEN": "test_admin_token_123",
-        "BOT_TOKEN": "test_bot_token_123",
-        "DATABASE_URL": "postgresql+psycopg://test:test@localhost:5433/test",
-        "REDIS_URL": "redis://localhost:6380/1",
-        "API_KEY": "test_api_key_123",
-        "WEBHOOK_SECRET": "test_webhook_secret",
-    }
-)
-
-# Add the app directory to the path so we can import the app modules
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from app.models import AuditLog
 from app.oauth import User

--- a/tests/test_authentication_authorization.py
+++ b/tests/test_authentication_authorization.py
@@ -8,32 +8,8 @@
 import hashlib
 import hmac
 import json
-import os
-import sys
 import unittest
-from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
-
-# Set test environment before any imports
-os.environ.update(
-    {
-        "SKIP_STARTUP_VALIDATION": "1",
-        "INSTANCE_BASE": "https://test.mastodon.social",
-        "ADMIN_TOKEN": "test_admin_token_123456789",
-        "BOT_TOKEN": "test_bot_token_123456789",
-        "DATABASE_URL": "postgresql+psycopg://test:test@localhost:5433/mastowatch_test",
-        "REDIS_URL": "redis://localhost:6380/1",
-        "OAUTH_CLIENT_ID": "test_oauth_client_id",
-        "OAUTH_CLIENT_SECRET": "test_oauth_client_secret",
-        "SESSION_SECRET_KEY": "test_session_secret_key_123456789",
-        "OAUTH_REDIRECT_URI": "http://localhost:8080/admin/callback",
-        "OAUTH_POPUP_REDIRECT_URI": "http://localhost:8080/admin/popup-callback",
-        "OAUTH_SCOPE": "read:accounts",
-    }
-)
-
-# Add the app directory to the path so we can import the app modules
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from fastapi.testclient import TestClient
 
@@ -57,7 +33,7 @@ class TestAuthenticationAuthorization(unittest.TestCase):
         self.mock_db.return_value.__enter__.return_value = self.mock_db_session
 
         # Mock OAuth config
-        self.oauth_patcher = patch("app.main.get_oauth_config")
+        self.oauth_patcher = patch("app.api.auth.get_oauth_config")
         self.mock_oauth_config = self.oauth_patcher.start()
         self.mock_oauth_instance = MagicMock()
         self.mock_oauth_instance.configured = True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,10 +1,5 @@
 import os
-import sys
 import unittest
-from pathlib import Path
-
-# Add the app directory to the path so we can import the app modules
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from app.config import Settings
 

--- a/tests/test_domain_validation_monitoring.py
+++ b/tests/test_domain_validation_monitoring.py
@@ -7,30 +7,9 @@
 - Integration with auto-generated Mastodon API client
 """
 
-import os
-import sys
 import unittest
 from datetime import datetime, timedelta
-from pathlib import Path
 from unittest.mock import MagicMock, patch
-
-# Set test environment before any imports
-os.environ.update(
-    {
-        "SKIP_STARTUP_VALIDATION": "1",
-        "INSTANCE_BASE": "https://test.mastodon.social",
-        "ADMIN_TOKEN": "test_admin_token_123456789",
-        "BOT_TOKEN": "test_bot_token_123456789",
-        "DATABASE_URL": "postgresql+psycopg://test:test@localhost:5433/mastowatch_test",
-        "REDIS_URL": "redis://localhost:6380/1",
-        "DEFEDERATION_THRESHOLD": "10",
-        "CONTENT_CACHE_TTL": "24",
-        "FEDERATED_SCAN_ENABLED": "true",
-    }
-)
-
-# Add the app directory to the path so we can import the app modules
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from fastapi.testclient import TestClient
 

--- a/tests/test_enhanced_scanning.py
+++ b/tests/test_enhanced_scanning.py
@@ -6,30 +6,9 @@
 - Session management and progress tracking
 """
 
-import os
-import sys
 import unittest
 from datetime import datetime
-from pathlib import Path
 from unittest.mock import MagicMock, patch
-
-# Set test environment before any imports
-os.environ.update(
-    {
-        "SKIP_STARTUP_VALIDATION": "1",
-        "INSTANCE_BASE": "https://test.mastodon.social",
-        "ADMIN_TOKEN": "test_admin_token_123456789",
-        "BOT_TOKEN": "test_bot_token_123456789",
-        "DATABASE_URL": "postgresql+psycopg://test:test@localhost:5433/mastowatch_test",
-        "REDIS_URL": "redis://localhost:6380/1",
-        "DEFEDERATION_THRESHOLD": "10",
-        "CONTENT_CACHE_TTL": "24",
-        "FEDERATED_SCAN_ENABLED": "true",
-    }
-)
-
-# Add the app directory to the path so we can import the app modules
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from app.schemas import Violation
 


### PR DESCRIPTION
## Summary
- centralize backend path injection and env var defaults in test configuration
- drop redundant setup code from individual tests
- fix missing `get_db` import in logs API

## Testing
- `make test` *(fails: AttributeError, AssertionError, IntegrityError)*

------
https://chatgpt.com/codex/tasks/task_e_6894e9bb94748322b9d63320adb81e9a