### PR TITLE
feat: add explicit MastoClient admin actions

### DIFF
--- a/docs/api-client-usage.md
+++ b/docs/api-client-usage.md
@@ -72,7 +72,7 @@ statuses = client.get_account_statuses("123", limit=10)
 ## Adding New Endpoints
 
 1. **First choice**: Use the generated client's HTTP session for the new endpoint
-2. **If complex**: Add a method to `MastoClient` that uses `_make_raw_request`
+2. **If complex**: Add a method to `MastoClient` using its private `_request` helper
 3. **Document** any endpoints not in the OpenAPI spec for future addition
 
 ## Testing

--- a/docs/mastodon-api-client.md
+++ b/docs/mastodon-api-client.md
@@ -69,11 +69,11 @@ report = client.create_report(
 print(f"Report created with ID: {report.id}")
 ```
 
-### Admin Operations (Fallback)
+### Admin Operations
 ```python
-# Admin endpoints not in OpenAPI spec use raw HTTP
-response = client.get_admin_accounts(origin="remote", limit=100)
-accounts = response.json()
+accounts, _ = client.get_admin_accounts(origin="remote", limit=100)
+client.warn_account("123", text="Please review the rules")
+client.unsilence_account("123")
 ```
 
 ## Management Commands

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -151,7 +151,7 @@ class TestEnforcementServiceLogging(unittest.TestCase):
         self.db_patcher = patch("app.services.enforcement_service.SessionLocal", self.SessionLocal)
         self.db_patcher.start()
         self.client = Mock()
-        self.client._make_request.return_value = Mock(json=lambda: {"ok": True})
+        self.client.warn_account.return_value = {"ok": True}
         self.service = EnforcementService(self.client)
 
     def tearDown(self):


### PR DESCRIPTION
## Summary
- add admin warning and un/silence/suspend helpers to MastoClient
- refactor enforcement service to use new MastoClient methods
- document admin helpers and client extension guidance

## Testing
- `make lint` *(fails: D102, D100, etc.)*
- `ruff check backend/app/mastodon_client.py backend/app/services/enforcement_service.py tests/test_services.py`
- `make typecheck` *(fails: Duplicate module named "auth")*
- `mypy backend/app/mastodon_client.py backend/app/services/enforcement_service.py` *(fails: missing imports)*
- `make test` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_689b00a6f2508322854f407b7f5978f8